### PR TITLE
Speedup reading of large DXF documents

### DIFF
--- a/TestDxfDocument/Program.cs
+++ b/TestDxfDocument/Program.cs
@@ -313,214 +313,12 @@ namespace TestDxfDocument
 
             //DxfDocument doc = Test(@"sample.dxf");
 
-            #region Samples for new and modified features 2.3.0
+            DateTime start = DateTime.UtcNow;
 
-            //ViewportTransform();
-            //MLineMirrorAndExplode();
-            //ShapeMirror();
-            //TextMirror();
-            //MTextMirror();
-            InsertMirror();
+            DxfDocument doc = DxfDocument.Load(@"C:\Users\TRI0002\Documents\My Received Files\266_full.dxf");
 
-            #endregion
-
-            #region Samples for new and modified features 2.2.1
-
-            //MTextParagraphFormatting();
-            //MTextCharacterFormatting();
-
-            #endregion
-
-            #region Samples for new and modified features 2.2.0
-
-            //AccessModelBlock();
-            //DimensionBlockGeneration();
-
-            #endregion
-
-            #region Samples for new and modified features 2.1.0
-
-            //Shape();
-            //ComplexLineType();
-            //TextStyle();
-            //ReadWriteFromStream();
-            //ReadWriteFromStream2();
-
-            #endregion
-
-            #region Samples for new and modified features 2.0.1
-
-            //DimensionUserTextWithTwoLines();
-
-            #endregion
-
-            #region Samples for new and modified features 2.0
-
-            //Polyline3dAddVertex();
-            //AcadTable();
-            //DimensionStyleOverrides();
-            //ResetLeaderAnnotationPosition();
-
-            #endregion
-
-            #region Samples for new and modified features 1.1.2
-
-            //LinearDimensionTest();
-            //AlignedDimensionTest();
-            //Angular2LineDimensionTest();
-            //Angular3PointDimensionTest();
-            //DiametricDimensionTest();
-            //RadialDimensionTest();
-            //OrdinateDimensionTest();
-
-            #endregion
-
-            #region Samples for new and modified features 1.1.0
-
-            //WipeoutEntity();
-            //ToleranceEntity();
-            //LeaderEntity();
-            //UnderlayEntity();
-            //SplineFitPoints();
-            //ImageClippingBoundary();
-
-            #endregion
-
-            #region Samples for new and modified features 1.0.2
-
-            //AssociativeHatches();
-            //TraceEntity();
-            //SolidEntity();
-
-            #endregion
-
-            #region Samples for new and modified features 1.0.0
-
-            //ModifyingDocumentEntities();
-            //ModifyingBlockProperties();
-            //ModifyingMLineStyles();
-            //DimensionsLinearAndAngularUnits();
-            //ModifyingDimensionGeometryAndStyle();
-            //ModifyingGroups();
-            //ModifyingXData();
-            //DimensionUserText();
-
-            #endregion
-
-            #region Samples for fixes, new and modified features 0.9.3
-
-            //RemoveBlock();
-            //LinearDimension();
-            //AlignedDimension();
-            //Angular2LineDimension();
-            //Angular3PointDimension();
-            //DiametricDimension();
-            //RadialDimension();
-            //OrdinateDimension();
-
-            #endregion
-
-            #region Samples for fixes, new and modified features 0.9.2
-
-            //NurbsEvaluator();
-            //XDataInformation();
-            //DynamicBlocks();
-
-            #endregion
-
-            #region Samples for fixes, new and modified features 0.9.1
-
-            //LoadAndSaveBlocks();
-
-            #endregion
-
-            #region Samples for fixes, new and modified features 0.9.0
-
-            //MakingGroups();
-            //CombiningTwoDrawings();
-            //BinaryChunkXData();
-            //BinaryDxfFiles();
-            //MeshEntity();
-
-            #endregion
-
-            #region Samples for new and modified features 0.8.0
-
-            //MTextEntity();
-            //TransparencySample();
-            //DocumentUnits();
-            //PaperSpace();
-            //BlockWithAttributes();
-
-            #endregion
-
-            #region other
-
-            //NestedBlock();
-            //DimensionNestedBlock();
-            //EncodingTest();
-            //CheckReferences();
-            //ComplexHatch();
-            //RayAndXLine();
-            //UserCoordinateSystems();
-            //ExplodeInsert();
-            //ImageUsesAndRemove();
-            //LayerAndLinetypesUsesAndRemove();
-            //TextAndDimensionStyleUsesAndRemove();
-            //MLineStyleUsesAndRemove();
-            //AppRegUsesAndRemove();
-            //ExplodePolyfaceMesh(); 
-            //ApplicationRegistries();
-            //TestOCStoWCS();
-            //WriteGradientPattern();
-            //WriteGroup();
-            //WriteMLine();
-            //ObjectVisibility();
-            //EntityTrueColor();
-            //EntityLineWeight();
-            //Text();
-            //WriteNoAsciiText();
-            //WriteSplineBoundaryHatch();
-            //WriteNoInsertBlock();
-            //WriteImage();
-            //AddAndRemove();
-            //LoadAndSave();
-            //CleanDrawing();
-            //OrdinateDimensionDrawing();
-            //Angular2LineDimensionDrawing();
-            //Angular3PointDimensionDrawing();
-            //DiametricDimensionDrawing();
-            //RadialDimensionDrawing();
-            //LinearDimensionDrawing();
-            //AlignedDimensionDrawing();
-            //WriteMText();
-            //LineWidth();
-            //HatchCircleBoundary();
-            //ToPolyline();
-            //FilesTest();
-            //CustomHatchPattern();
-            //LoadSaveHatchTest();
-            //WriteDxfFile();
-            //ReadDxfFile();
-            //ExplodeTest();
-            //HatchTestLinesBoundary();
-            //HatchTest1();
-            //HatchTest2();
-            //HatchTest3();
-            //HatchTest4();
-            //WriteNestedInsert();
-            //WritePolyfaceMesh();
-            //Ellipse();
-            //Solid();
-            //Face3d();
-            //LwPolyline();
-            //Polyline();
-            //Dxf2000();
-            //SpeedTest();
-            //WritePolyline3d();
-            //WriteInsert();
-
-            #endregion
+            Console.WriteLine("Loading DXF took " + (DateTime.UtcNow - start).TotalMilliseconds.ToString() + "ms");
+            Console.ReadLine();
         }
 
         #region Samples for new and modified features 2.3.0
@@ -953,7 +751,7 @@ namespace TestDxfDocument
 
             // Something similar can be done when removing entities from a document
             // pick up the first entity of the list, we now in advance it will be a line (in reality it might contain any kind of entity)
-            Line delete = (Line) loaded.Blocks[Block.DefaultModelSpaceName].Entities[0];
+            Line delete = (Line) loaded.Blocks[Block.DefaultModelSpaceName].Entities.First();
 
             bool isDeleted;
             // this was the way of removing entities from the document ( isDeleted = true)
@@ -966,7 +764,7 @@ namespace TestDxfDocument
 
             // or we can access the owner of the line 
             // pick up another line from the document, the old one has now owner anymore
-            delete = (Line)loaded.Blocks[Block.DefaultModelSpaceName].Entities[0];
+            delete = (Line)loaded.Blocks[Block.DefaultModelSpaceName].Entities.First();
             isDeleted = loaded.Blocks[delete.Owner.Name].Entities.Remove(delete); // (isDeleted = true)
 
             // only one more line remains in the document

--- a/TestDxfDocument/Program.cs
+++ b/TestDxfDocument/Program.cs
@@ -313,12 +313,214 @@ namespace TestDxfDocument
 
             //DxfDocument doc = Test(@"sample.dxf");
 
-            DateTime start = DateTime.UtcNow;
+            #region Samples for new and modified features 2.3.0
 
-            DxfDocument doc = DxfDocument.Load(@"C:\Users\TRI0002\Documents\My Received Files\266_full.dxf");
+            //ViewportTransform();
+            //MLineMirrorAndExplode();
+            //ShapeMirror();
+            //TextMirror();
+            //MTextMirror();
+            InsertMirror();
 
-            Console.WriteLine("Loading DXF took " + (DateTime.UtcNow - start).TotalMilliseconds.ToString() + "ms");
-            Console.ReadLine();
+            #endregion
+
+            #region Samples for new and modified features 2.2.1
+
+            //MTextParagraphFormatting();
+            //MTextCharacterFormatting();
+
+            #endregion
+
+            #region Samples for new and modified features 2.2.0
+
+            //AccessModelBlock();
+            //DimensionBlockGeneration();
+
+            #endregion
+
+            #region Samples for new and modified features 2.1.0
+
+            //Shape();
+            //ComplexLineType();
+            //TextStyle();
+            //ReadWriteFromStream();
+            //ReadWriteFromStream2();
+
+            #endregion
+
+            #region Samples for new and modified features 2.0.1
+
+            //DimensionUserTextWithTwoLines();
+
+            #endregion
+
+            #region Samples for new and modified features 2.0
+
+            //Polyline3dAddVertex();
+            //AcadTable();
+            //DimensionStyleOverrides();
+            //ResetLeaderAnnotationPosition();
+
+            #endregion
+
+            #region Samples for new and modified features 1.1.2
+
+            //LinearDimensionTest();
+            //AlignedDimensionTest();
+            //Angular2LineDimensionTest();
+            //Angular3PointDimensionTest();
+            //DiametricDimensionTest();
+            //RadialDimensionTest();
+            //OrdinateDimensionTest();
+
+            #endregion
+
+            #region Samples for new and modified features 1.1.0
+
+            //WipeoutEntity();
+            //ToleranceEntity();
+            //LeaderEntity();
+            //UnderlayEntity();
+            //SplineFitPoints();
+            //ImageClippingBoundary();
+
+            #endregion
+
+            #region Samples for new and modified features 1.0.2
+
+            //AssociativeHatches();
+            //TraceEntity();
+            //SolidEntity();
+
+            #endregion
+
+            #region Samples for new and modified features 1.0.0
+
+            //ModifyingDocumentEntities();
+            //ModifyingBlockProperties();
+            //ModifyingMLineStyles();
+            //DimensionsLinearAndAngularUnits();
+            //ModifyingDimensionGeometryAndStyle();
+            //ModifyingGroups();
+            //ModifyingXData();
+            //DimensionUserText();
+
+            #endregion
+
+            #region Samples for fixes, new and modified features 0.9.3
+
+            //RemoveBlock();
+            //LinearDimension();
+            //AlignedDimension();
+            //Angular2LineDimension();
+            //Angular3PointDimension();
+            //DiametricDimension();
+            //RadialDimension();
+            //OrdinateDimension();
+
+            #endregion
+
+            #region Samples for fixes, new and modified features 0.9.2
+
+            //NurbsEvaluator();
+            //XDataInformation();
+            //DynamicBlocks();
+
+            #endregion
+
+            #region Samples for fixes, new and modified features 0.9.1
+
+            //LoadAndSaveBlocks();
+
+            #endregion
+
+            #region Samples for fixes, new and modified features 0.9.0
+
+            //MakingGroups();
+            //CombiningTwoDrawings();
+            //BinaryChunkXData();
+            //BinaryDxfFiles();
+            //MeshEntity();
+
+            #endregion
+
+            #region Samples for new and modified features 0.8.0
+
+            //MTextEntity();
+            //TransparencySample();
+            //DocumentUnits();
+            //PaperSpace();
+            //BlockWithAttributes();
+
+            #endregion
+
+            #region other
+
+            //NestedBlock();
+            //DimensionNestedBlock();
+            //EncodingTest();
+            //CheckReferences();
+            //ComplexHatch();
+            //RayAndXLine();
+            //UserCoordinateSystems();
+            //ExplodeInsert();
+            //ImageUsesAndRemove();
+            //LayerAndLinetypesUsesAndRemove();
+            //TextAndDimensionStyleUsesAndRemove();
+            //MLineStyleUsesAndRemove();
+            //AppRegUsesAndRemove();
+            //ExplodePolyfaceMesh(); 
+            //ApplicationRegistries();
+            //TestOCStoWCS();
+            //WriteGradientPattern();
+            //WriteGroup();
+            //WriteMLine();
+            //ObjectVisibility();
+            //EntityTrueColor();
+            //EntityLineWeight();
+            //Text();
+            //WriteNoAsciiText();
+            //WriteSplineBoundaryHatch();
+            //WriteNoInsertBlock();
+            //WriteImage();
+            //AddAndRemove();
+            //LoadAndSave();
+            //CleanDrawing();
+            //OrdinateDimensionDrawing();
+            //Angular2LineDimensionDrawing();
+            //Angular3PointDimensionDrawing();
+            //DiametricDimensionDrawing();
+            //RadialDimensionDrawing();
+            //LinearDimensionDrawing();
+            //AlignedDimensionDrawing();
+            //WriteMText();
+            //LineWidth();
+            //HatchCircleBoundary();
+            //ToPolyline();
+            //FilesTest();
+            //CustomHatchPattern();
+            //LoadSaveHatchTest();
+            //WriteDxfFile();
+            //ReadDxfFile();
+            //ExplodeTest();
+            //HatchTestLinesBoundary();
+            //HatchTest1();
+            //HatchTest2();
+            //HatchTest3();
+            //HatchTest4();
+            //WriteNestedInsert();
+            //WritePolyfaceMesh();
+            //Ellipse();
+            //Solid();
+            //Face3d();
+            //LwPolyline();
+            //Polyline();
+            //Dxf2000();
+            //SpeedTest();
+            //WritePolyline3d();
+            //WriteInsert();
+
+            #endregion
         }
 
         #region Samples for new and modified features 2.3.0

--- a/netDxf/Collections/EntityCollection.cs
+++ b/netDxf/Collections/EntityCollection.cs
@@ -123,31 +123,6 @@ namespace netDxf.Collections
         #region public properties
 
         /// <summary>
-        /// Gets or sets the <see cref="EntityObject">entity</see> at the specified index.
-        /// </summary>
-        /// <param name="index"> The zero-based index of the element to get or set.</param>
-        /// <returns>The <see cref="EntityObject">entity</see> at the specified index.</returns>
-        /*public EntityObject this[int index]
-        {
-            get { return this.innerArray[index]; }
-            set
-            {
-                if (value == null)
-                    throw new ArgumentNullException(nameof(value));
-
-                EntityObject remove = this.innerArray[index];
-
-                if (this.OnBeforeRemoveItemEvent(remove))
-                    return;
-                if (this.OnBeforeAddItemEvent(value))
-                    return;
-                this.innerArray[index] = value;
-                this.OnAddItemEvent(value);
-                this.OnRemoveItemEvent(remove);
-            }
-        }*/
-
-        /// <summary>
         /// Gets the number of <see cref="EntityObject">entities</see> contained in the collection.
         /// </summary>
         public int Count
@@ -193,24 +168,6 @@ namespace netDxf.Collections
         }
 
         /// <summary>
-        /// Inserts an <see cref="EntityObject">entity</see> into the collection at the specified index.
-        /// </summary>
-        /// <param name="index">The zero-based index at which item should be inserted.</param>
-        /// <param name="item">The <see cref="EntityObject">entity</see> to insert. The value can not be null.</param>
-        /*public void Insert(int index, EntityObject item)
-        {
-            if (index < 0 || index >= this.innerArray.Count)
-                throw new ArgumentOutOfRangeException(string.Format("The parameter index {0} must be in between {1} and {2}.", index, 0, this.innerArray.Count));
-            if (this.OnBeforeRemoveItemEvent(this.innerArray[index]))
-                return;
-            if (this.OnBeforeAddItemEvent(item))
-                throw new ArgumentException("The entity cannot be added to the collection.", nameof(item));
-            this.OnRemoveItemEvent(this.innerArray[index]);
-            this.innerArray.Insert(index, item);
-            this.OnAddItemEvent(item);
-        }*/
-
-        /// <summary>
         /// Removes the first occurrence of a specific <see cref="EntityObject">entity</see> from the collection
         /// </summary>
         /// <param name="item">The <see cref="EntityObject">entity</see> to remove from the collection.</param>
@@ -241,21 +198,6 @@ namespace netDxf.Collections
         }
 
         /// <summary>
-        /// Removes the <see cref="EntityObject">entity</see> at the specified index of the collection.
-        /// </summary>
-        /// <param name="index">The zero-based index of the <see cref="EntityObject">entity</see> to remove.</param>
-        /*public void RemoveAt(int index)
-        {
-            if (index < 0 || index >= this.innerArray.Count)
-                throw new ArgumentOutOfRangeException(string.Format("The parameter index {0} must be in between {1} and {2}.", index, 0, this.innerArray.Count));
-            EntityObject remove = this.innerArray[index];
-            if (this.OnBeforeRemoveItemEvent(remove))
-                return;
-            this.innerArray.RemoveAt(index);
-            this.OnRemoveItemEvent(remove);
-        }*/
-
-        /// <summary>
         /// Removes all <see cref="EntityObject">entities</see> from the collection.
         /// </summary>
         public void Clear()
@@ -265,16 +207,6 @@ namespace netDxf.Collections
             foreach (EntityObject item in entities)
                 this.Remove(item);
         }
-
-        /// <summary>
-        /// Searches for the specified <see cref="EntityObject">entity</see> and returns the zero-based index of the first occurrence within the entire collection.
-        /// </summary>
-        /// <param name="item">The <see cref="EntityObject">entity</see> to locate in the collection.</param>
-        /// <returns>The zero-based index of the first occurrence of item within the entire collection, if found; otherwise, –1.</returns>
-        /*public int IndexOf(EntityObject item)
-        {
-            return this.innerArray.IndexOf(item);
-        }*/
 
         /// <summary>
         /// Determines whether an <see cref="EntityObject">entity</see> is in the collection.

--- a/netDxf/Collections/EntityCollection.cs
+++ b/netDxf/Collections/EntityCollection.cs
@@ -31,7 +31,7 @@ namespace netDxf.Collections
     /// Represent a collection of <see cref="EntityObject">entities</see> that fire events when it is modified. 
     /// </summary>
     public class EntityCollection :
-        IList<EntityObject>
+        IEnumerable<EntityObject>
     {
         #region delegates and events
 
@@ -93,7 +93,7 @@ namespace netDxf.Collections
 
         #region private fields
 
-        private readonly List<EntityObject> innerArray;
+        private readonly HashSet<EntityObject> innerArray;
 
         #endregion
 
@@ -104,7 +104,7 @@ namespace netDxf.Collections
         /// </summary>
         public EntityCollection()
         {
-            this.innerArray = new List<EntityObject>();
+            this.innerArray = new HashSet<EntityObject>();
         }
 
         /// <summary>
@@ -115,7 +115,7 @@ namespace netDxf.Collections
         {
             if (capacity < 0)
                 throw new ArgumentOutOfRangeException(nameof(capacity), "The collection capacity cannot be negative.");
-            this.innerArray = new List<EntityObject>(capacity);
+            this.innerArray = new HashSet<EntityObject>();
         }
 
         #endregion
@@ -127,7 +127,7 @@ namespace netDxf.Collections
         /// </summary>
         /// <param name="index"> The zero-based index of the element to get or set.</param>
         /// <returns>The <see cref="EntityObject">entity</see> at the specified index.</returns>
-        public EntityObject this[int index]
+        /*public EntityObject this[int index]
         {
             get { return this.innerArray[index]; }
             set
@@ -145,7 +145,7 @@ namespace netDxf.Collections
                 this.OnAddItemEvent(value);
                 this.OnRemoveItemEvent(remove);
             }
-        }
+        }*/
 
         /// <summary>
         /// Gets the number of <see cref="EntityObject">entities</see> contained in the collection.
@@ -197,7 +197,7 @@ namespace netDxf.Collections
         /// </summary>
         /// <param name="index">The zero-based index at which item should be inserted.</param>
         /// <param name="item">The <see cref="EntityObject">entity</see> to insert. The value can not be null.</param>
-        public void Insert(int index, EntityObject item)
+        /*public void Insert(int index, EntityObject item)
         {
             if (index < 0 || index >= this.innerArray.Count)
                 throw new ArgumentOutOfRangeException(string.Format("The parameter index {0} must be in between {1} and {2}.", index, 0, this.innerArray.Count));
@@ -208,7 +208,7 @@ namespace netDxf.Collections
             this.OnRemoveItemEvent(this.innerArray[index]);
             this.innerArray.Insert(index, item);
             this.OnAddItemEvent(item);
-        }
+        }*/
 
         /// <summary>
         /// Removes the first occurrence of a specific <see cref="EntityObject">entity</see> from the collection
@@ -244,7 +244,7 @@ namespace netDxf.Collections
         /// Removes the <see cref="EntityObject">entity</see> at the specified index of the collection.
         /// </summary>
         /// <param name="index">The zero-based index of the <see cref="EntityObject">entity</see> to remove.</param>
-        public void RemoveAt(int index)
+        /*public void RemoveAt(int index)
         {
             if (index < 0 || index >= this.innerArray.Count)
                 throw new ArgumentOutOfRangeException(string.Format("The parameter index {0} must be in between {1} and {2}.", index, 0, this.innerArray.Count));
@@ -253,7 +253,7 @@ namespace netDxf.Collections
                 return;
             this.innerArray.RemoveAt(index);
             this.OnRemoveItemEvent(remove);
-        }
+        }*/
 
         /// <summary>
         /// Removes all <see cref="EntityObject">entities</see> from the collection.
@@ -271,10 +271,10 @@ namespace netDxf.Collections
         /// </summary>
         /// <param name="item">The <see cref="EntityObject">entity</see> to locate in the collection.</param>
         /// <returns>The zero-based index of the first occurrence of item within the entire collection, if found; otherwise, –1.</returns>
-        public int IndexOf(EntityObject item)
+        /*public int IndexOf(EntityObject item)
         {
             return this.innerArray.IndexOf(item);
-        }
+        }*/
 
         /// <summary>
         /// Determines whether an <see cref="EntityObject">entity</see> is in the collection.
@@ -308,16 +308,6 @@ namespace netDxf.Collections
         #endregion
 
         #region private methods
-
-        void ICollection<EntityObject>.Add(EntityObject item)
-        {
-            this.Add(item);
-        }
-
-        void IList<EntityObject>.Insert(int index, EntityObject item)
-        {
-            this.Insert(index, item);
-        }
 
         IEnumerator IEnumerable.GetEnumerator()
         {

--- a/netDxf/Objects/Group.cs
+++ b/netDxf/Objects/Group.cs
@@ -124,7 +124,7 @@ namespace netDxf.Objects
             this.entities.AddItem += this.Entities_AddItem;
             this.entities.BeforeRemoveItem += this.Entities_BeforeRemoveItem;
             this.entities.RemoveItem += this.Entities_RemoveItem;
-            if (entities != null)
+            if(entities != null)
                 this.entities.AddRange(entities);
         }
 
@@ -203,7 +203,7 @@ namespace netDxf.Objects
         /// </summary>
         public new Groups Owner
         {
-            get { return (Groups)base.Owner; }
+            get { return(Groups)base.Owner; }
             internal set { base.Owner = value; }
         }
 

--- a/netDxf/Objects/Group.cs
+++ b/netDxf/Objects/Group.cs
@@ -124,7 +124,7 @@ namespace netDxf.Objects
             this.entities.AddItem += this.Entities_AddItem;
             this.entities.BeforeRemoveItem += this.Entities_BeforeRemoveItem;
             this.entities.RemoveItem += this.Entities_RemoveItem;
-            if(entities != null)
+            if (entities != null)
                 this.entities.AddRange(entities);
         }
 
@@ -203,7 +203,7 @@ namespace netDxf.Objects
         /// </summary>
         public new Groups Owner
         {
-            get { return (Groups) base.Owner; }
+            get { return (Groups)base.Owner; }
             internal set { base.Owner = value; }
         }
 
@@ -220,9 +220,11 @@ namespace netDxf.Objects
         public override TableObject Clone(string newName)
         {
             EntityObject[] refs = new EntityObject[this.entities.Count];
-            for (int i = 0; i < this.entities.Count; i++)
+            int i = 0;
+            foreach (var entity in this.entities)
             {
-                refs[i] = (EntityObject) this.entities[i].Clone();
+                refs[i] = (EntityObject)entity.Clone();
+                i++;
             }
 
             Group copy = new Group(newName, refs)

--- a/netDxf/Tables/TableObject.cs
+++ b/netDxf/Tables/TableObject.cs
@@ -22,6 +22,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using netDxf.Collections;
 
 namespace netDxf.Tables
@@ -71,7 +72,7 @@ namespace netDxf.Tables
 
         #region private fields
 
-        private static readonly IReadOnlyList<string> invalidCharacters = new[] {"\\", "/", ":", "*", "?", "\"", "<", ">", "|", ";", ",", "=", "`"};
+        private static char[] invalidCharacters = new[] { '\\', '/', ':', '*', '?', '"', '<', '>', '|', ';', ',', '=', '`' };
         private bool reserved;
         private string name;
         private readonly XDataDictionary xData;
@@ -130,7 +131,7 @@ namespace netDxf.Tables
         /// </summary>
         public static IReadOnlyList<string> InvalidCharacters
         {
-            get { return invalidCharacters; }
+            get { return invalidCharacters.Select(c => c.ToString()).ToList(); }
         }
 
         /// <summary>
@@ -155,17 +156,7 @@ namespace netDxf.Tables
             if (string.IsNullOrEmpty(name))
                 return false;
 
-            foreach (string s in InvalidCharacters)
-            {
-                if (name.Contains(s))
-                    return false;
-            }
-
-            // using regular expressions is slower
-            //if (Regex.IsMatch(name, "[\\<>/?\":;*|,=`]"))
-            //    throw new ArgumentException("The following characters \\<>/?\":;*|,=` are not supported for table object names.", "name");
-
-            return true;
+            return name.IndexOfAny(invalidCharacters) == -1;
         }
 
         #endregion


### PR DESCRIPTION
I'm testing out the capabilities of netDxf in a project I'm working on. I've noticed that loading large documents takes a pretty long time. After taking the code through the performance analyzer, I noticed two low hanging fruit optimizations.

The first one is to switch the internal list of EntityCollection to a HashSet. Most of the CPU time for loading the file was spent in the 'Contains' method of the internal list. This means there is no index based retrieving of entities anymore though. HashSet is much more  performant in checking if an object is already contained in the collection. You might want to keep both a HashSet and a List internally if index based retrieval is a must. There would be some syncing logic but I think it will still be way faster.

This change reduced the loading time of a 5MB DXF file from 13.9 seconds to 2.5 seconds.

The seconds one is in the function of IsValidName. The fastest way I could find was to use the IndexOfAny method. This further reduces the loading time of my file from 2.5 to 1.8 seconds.

Feel free to make or suggest changes if you've unhappy with some part of the PR.