### PR TITLE
Remove Restriction for Attribute Def Tag to Not Have Spaces

### DIFF
--- a/netDxf/Entities/AttributeDefinition.cs
+++ b/netDxf/Entities/AttributeDefinition.cs
@@ -165,8 +165,6 @@ namespace netDxf.Entities
             if (string.IsNullOrEmpty(tag))
                 throw new ArgumentNullException(nameof(tag));
 
-            if (tag.Contains(" "))
-                throw new ArgumentException("The tag string cannot contain spaces.", nameof(tag));
             this.tag = tag;
             this.flags = AttributeFlags.Visible;
             this.prompt = string.Empty;


### PR DESCRIPTION
It is valid for a dxf to have spaces in the Attribute Definition Tag (although the Autocad UI may not allow it when editing).