### PR TITLE
Possible solution for Issue146

### DIFF
--- a/netDxf/Header/HeaderVariables.cs
+++ b/netDxf/Header/HeaderVariables.cs
@@ -51,7 +51,7 @@ namespace netDxf.Header
             this.variables = new Dictionary<string, HeaderVariable>(StringComparer.OrdinalIgnoreCase)
             {
                 {HeaderVariableCode.AcadVer, new HeaderVariable(HeaderVariableCode.AcadVer, 1, DxfVersion.AutoCad2000)},
-                {HeaderVariableCode.DwgCodePage, new HeaderVariable(HeaderVariableCode.DwgCodePage, 3, "ANSI_" + Encoding.Default.WindowsCodePage)},
+                {HeaderVariableCode.DwgCodePage, new HeaderVariable(HeaderVariableCode.DwgCodePage, 3, "ANSI_" + Encoding.ASCII.WindowsCodePage)},
                 {HeaderVariableCode.LastSavedBy, new HeaderVariable(HeaderVariableCode.LastSavedBy, 1, Environment.UserName)},
                 {HeaderVariableCode.HandleSeed, new HeaderVariable(HeaderVariableCode.HandleSeed, 5, "1")},
                 {HeaderVariableCode.Angbase, new HeaderVariable(HeaderVariableCode.Angbase, 50, 0.0)},


### PR DESCRIPTION
Adding this pull request for the purposes of discussion.  The rationale is that, since Encoding.ASCII is used in `DxfWriter` for writing all non-unicode DXF files, using it to populate the header should mean that the code page in the header accurately describes the file encoding.