### PR TITLE
Corrected AciColor color table:

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,4 @@ FakesAssemblies/
 # Visual Studio 6 workspace options file
 *.opt
 
+*.DotSettings

--- a/netDxf/AciColor.ColorDictionary.cs
+++ b/netDxf/AciColor.ColorDictionary.cs
@@ -1,0 +1,114 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+
+namespace netDxf {
+
+    partial class AciColor {
+
+        /// <summary>
+        /// Wraps <see cref="AciColor.LookUpRgb"/> function in <see cref="IReadOnlyDictionary{TKey,TValue}"/>
+        /// of Autocad Color Indexes (ACI) palette. Keys are ACI color index,
+        /// values are array of bytes, where red == byte[0], green == byte[1] and blue = byte[2].
+        /// </summary>
+        private class AciColorDictionary : IReadOnlyDictionary<byte, byte[]>
+        {
+            private struct Enumerator : IEnumerator<KeyValuePair<byte, byte[]>>
+            {
+                private byte index;
+
+                public void Dispose() {}
+
+                public bool MoveNext()
+                {
+                    if (this.index == byte.MaxValue)
+                        return false;
+
+                    this.index++;
+                    return true;
+                }
+
+                public void Reset() { this.index = 0; }
+                public KeyValuePair<byte, byte[]> Current
+                {
+                    get {
+                        return this.index == 0
+                            ? default(KeyValuePair<byte, byte[]>)
+                            : new KeyValuePair<byte, byte[]>(this.index, RgbToArray(this.index));
+                    }
+                }
+
+                object IEnumerator.Current
+                {
+                    get { return this.Current; }
+                }
+
+            }
+
+            public IEnumerator<KeyValuePair<byte, byte[]>> GetEnumerator()
+            {
+                return new Enumerator();
+            }
+
+            IEnumerator IEnumerable.GetEnumerator()
+            {
+                return new Enumerator();
+            }
+
+            public int Count
+            {
+                get { return byte.MaxValue; }
+            }
+
+            public bool ContainsKey(byte key) { return key != 0; }
+
+            public bool TryGetValue(byte key, out byte[] value)
+            {
+                if (key == 0)
+                {
+                    value = null;
+                    return false;
+                }
+
+                value = RgbToArray(key);
+                return true;
+            }
+
+            private static byte[] RgbToArray(byte colorIndex)
+            {
+                if (colorIndex == 0)
+                    throw new KeyNotFoundException("ACI index shold be greater then zero.");
+
+                int rgb = LookUpRgb(colorIndex);
+
+                return new[] {
+                    (byte)(rgb >> 16),
+                    (byte)(rgb >> 8),
+                    (byte)rgb
+                };
+            }
+
+            public byte[] this[byte key]
+            {
+                get { return RgbToArray(key); }
+            }
+
+            public IEnumerable<byte> Keys
+            {
+                get {
+                    for (int i = 1; i <= byte.MaxValue; i++)
+                        yield return (byte)i;
+                }
+            }
+
+            public IEnumerable<byte[]> Values
+            {
+                get {
+                    for (int i = 1; i <= byte.MaxValue; i++)
+                        yield return this[(byte)i];
+                }
+            }
+
+        }
+    }
+
+}

--- a/netDxf/AciColor.cs
+++ b/netDxf/AciColor.cs
@@ -31,272 +31,10 @@ namespace netDxf
     /// <summary>
     /// Represents an ACI color (AutoCAD Color Index) that also supports true color.
     /// </summary>
-    public class AciColor :
+    public partial class AciColor :
         ICloneable,
         IEquatable<AciColor>
     {
-        #region list of the indexed colors
-
-        private static readonly IReadOnlyDictionary<byte, byte[]> indexRgb = new Dictionary<byte, byte[]>
-        {
-            {1, new byte[] {255, 0, 0}},
-            {2, new byte[] {255, 255, 0}},
-            {3, new byte[] {0, 255, 0}},
-            {4, new byte[] {0, 255, 255}},
-            {5, new byte[] {0, 0, 255}},
-            {6, new byte[] {255, 0, 255}},
-            {7, new byte[] {255, 255, 255}},
-            {8, new byte[] {128, 128, 128}},
-            {9, new byte[] {192, 192, 192}},
-            {10, new byte[] {255, 0, 0}},
-            {11, new byte[] {255, 127, 127}},
-            {12, new byte[] {165, 0, 0}},
-            {13, new byte[] {165, 82, 82}},
-            {14, new byte[] {127, 0, 0}},
-            {15, new byte[] {127, 63, 63}},
-            {16, new byte[] {76, 0, 0}},
-            {17, new byte[] {76, 38, 38}},
-            {18, new byte[] {38, 0, 0}},
-            {19, new byte[] {38, 19, 19}},
-            {20, new byte[] {255, 63, 0}},
-            {21, new byte[] {255, 159, 127}},
-            {22, new byte[] {165, 41, 0}},
-            {23, new byte[] {165, 103, 82}},
-            {24, new byte[] {127, 31, 0}},
-            {25, new byte[] {127, 79, 63}},
-            {26, new byte[] {76, 19, 0}},
-            {27, new byte[] {76, 47, 38}},
-            {28, new byte[] {38, 9, 0}},
-            {29, new byte[] {38, 23, 19}},
-            {30, new byte[] {255, 127, 0}},
-            {31, new byte[] {255, 191, 127}},
-            {32, new byte[] {165, 82, 0}},
-            {33, new byte[] {165, 124, 82}},
-            {34, new byte[] {127, 63, 0}},
-            {35, new byte[] {127, 95, 63}},
-            {36, new byte[] {76, 38, 0}},
-            {37, new byte[] {76, 57, 38}},
-            {38, new byte[] {38, 19, 0}},
-            {39, new byte[] {38, 28, 19}},
-            {40, new byte[] {255, 191, 0}},
-            {41, new byte[] {255, 223, 127}},
-            {42, new byte[] {165, 124, 0}},
-            {43, new byte[] {165, 145, 82}},
-            {44, new byte[] {127, 95, 0}},
-            {45, new byte[] {127, 111, 63}},
-            {46, new byte[] {76, 57, 0}},
-            {47, new byte[] {76, 66, 38}},
-            {48, new byte[] {38, 28, 0}},
-            {49, new byte[] {38, 33, 19}},
-            {50, new byte[] {255, 255, 0}},
-            {51, new byte[] {255, 255, 127}},
-            {52, new byte[] {165, 165, 0}},
-            {53, new byte[] {165, 165, 82}},
-            {54, new byte[] {127, 127, 0}},
-            {55, new byte[] {127, 127, 63}},
-            {56, new byte[] {76, 76, 0}},
-            {57, new byte[] {76, 76, 38}},
-            {58, new byte[] {38, 38, 0}},
-            {59, new byte[] {38, 38, 19}},
-            {60, new byte[] {191, 255, 0}},
-            {61, new byte[] {223, 255, 127}},
-            {62, new byte[] {124, 165, 0}},
-            {63, new byte[] {145, 165, 82}},
-            {64, new byte[] {95, 127, 0}},
-            {65, new byte[] {111, 127, 63}},
-            {66, new byte[] {57, 76, 0}},
-            {67, new byte[] {66, 76, 38}},
-            {68, new byte[] {28, 38, 0}},
-            {69, new byte[] {33, 38, 19}},
-            {70, new byte[] {127, 255, 0}},
-            {71, new byte[] {191, 255, 127}},
-            {72, new byte[] {82, 165, 0}},
-            {73, new byte[] {124, 165, 82}},
-            {74, new byte[] {63, 127, 0}},
-            {75, new byte[] {95, 127, 63}},
-            {76, new byte[] {38, 76, 0}},
-            {77, new byte[] {57, 76, 38}},
-            {78, new byte[] {19, 38, 0}},
-            {79, new byte[] {28, 38, 19}},
-            {80, new byte[] {63, 255, 0}},
-            {81, new byte[] {159, 255, 127}},
-            {82, new byte[] {41, 165, 0}},
-            {83, new byte[] {103, 165, 82}},
-            {84, new byte[] {31, 127, 0}},
-            {85, new byte[] {79, 127, 63}},
-            {86, new byte[] {19, 76, 0}},
-            {87, new byte[] {47, 76, 38}},
-            {88, new byte[] {9, 38, 0}},
-            {89, new byte[] {23, 38, 19}},
-            {90, new byte[] {0, 255, 0}},
-            {91, new byte[] {127, 255, 127}},
-            {92, new byte[] {0, 165, 0}},
-            {93, new byte[] {82, 165, 82}},
-            {94, new byte[] {0, 127, 0}},
-            {95, new byte[] {63, 127, 63}},
-            {96, new byte[] {0, 76, 0}},
-            {97, new byte[] {38, 76, 38}},
-            {98, new byte[] {0, 38, 0}},
-            {99, new byte[] {19, 38, 19}},
-            {100, new byte[] {0, 255, 63}},
-            {101, new byte[] {127, 255, 159}},
-            {102, new byte[] {0, 165, 41}},
-            {103, new byte[] {82, 165, 103}},
-            {104, new byte[] {0, 127, 31}},
-            {105, new byte[] {63, 127, 79}},
-            {106, new byte[] {0, 76, 19}},
-            {107, new byte[] {38, 76, 47}},
-            {108, new byte[] {0, 38, 9}},
-            {109, new byte[] {19, 38, 23}},
-            {110, new byte[] {0, 255, 127}},
-            {111, new byte[] {127, 255, 191}},
-            {112, new byte[] {0, 165, 82}},
-            {113, new byte[] {82, 165, 124}},
-            {114, new byte[] {0, 127, 63}},
-            {115, new byte[] {63, 127, 95}},
-            {116, new byte[] {0, 76, 38}},
-            {117, new byte[] {38, 76, 57}},
-            {118, new byte[] {0, 38, 19}},
-            {119, new byte[] {19, 38, 28}},
-            {120, new byte[] {0, 255, 191}},
-            {121, new byte[] {127, 255, 223}},
-            {122, new byte[] {0, 165, 124}},
-            {123, new byte[] {82, 165, 145}},
-            {124, new byte[] {0, 127, 95}},
-            {125, new byte[] {63, 127, 111}},
-            {126, new byte[] {0, 76, 57}},
-            {127, new byte[] {38, 76, 66}},
-            {128, new byte[] {0, 38, 28}},
-            {129, new byte[] {19, 38, 33}},
-            {130, new byte[] {0, 255, 255}},
-            {131, new byte[] {127, 255, 255}},
-            {132, new byte[] {0, 165, 165}},
-            {133, new byte[] {82, 165, 165}},
-            {134, new byte[] {0, 127, 127}},
-            {135, new byte[] {63, 127, 127}},
-            {136, new byte[] {0, 76, 76}},
-            {137, new byte[] {38, 76, 76}},
-            {138, new byte[] {0, 38, 38}},
-            {139, new byte[] {19, 38, 38}},
-            {140, new byte[] {0, 191, 255}},
-            {141, new byte[] {127, 223, 255}},
-            {142, new byte[] {0, 124, 165}},
-            {143, new byte[] {82, 145, 165}},
-            {144, new byte[] {0, 95, 127}},
-            {145, new byte[] {63, 111, 127}},
-            {146, new byte[] {0, 57, 76}},
-            {147, new byte[] {38, 66, 76}},
-            {148, new byte[] {0, 28, 38}},
-            {149, new byte[] {19, 33, 38}},
-            {150, new byte[] {0, 127, 255}},
-            {151, new byte[] {127, 191, 255}},
-            {152, new byte[] {0, 82, 165}},
-            {153, new byte[] {82, 124, 165}},
-            {154, new byte[] {0, 63, 127}},
-            {155, new byte[] {63, 95, 127}},
-            {156, new byte[] {0, 38, 76}},
-            {157, new byte[] {38, 57, 76}},
-            {158, new byte[] {0, 19, 38}},
-            {159, new byte[] {19, 28, 38}},
-            {160, new byte[] {0, 63, 255}},
-            {161, new byte[] {127, 159, 255}},
-            {162, new byte[] {0, 41, 165}},
-            {163, new byte[] {82, 103, 165}},
-            {164, new byte[] {0, 31, 127}},
-            {165, new byte[] {63, 79, 127}},
-            {166, new byte[] {0, 19, 76}},
-            {167, new byte[] {38, 47, 76}},
-            {168, new byte[] {0, 9, 38}},
-            {169, new byte[] {19, 23, 38}},
-            {170, new byte[] {0, 0, 255}},
-            {171, new byte[] {127, 127, 255}},
-            {172, new byte[] {0, 0, 165}},
-            {173, new byte[] {82, 82, 165}},
-            {174, new byte[] {0, 0, 127}},
-            {175, new byte[] {63, 63, 127}},
-            {176, new byte[] {0, 0, 76}},
-            {177, new byte[] {38, 38, 76}},
-            {178, new byte[] {0, 0, 38}},
-            {179, new byte[] {19, 19, 38}},
-            {180, new byte[] {63, 0, 255}},
-            {181, new byte[] {159, 127, 255}},
-            {182, new byte[] {41, 0, 165}},
-            {183, new byte[] {103, 82, 165}},
-            {184, new byte[] {31, 0, 127}},
-            {185, new byte[] {79, 63, 127}},
-            {186, new byte[] {19, 0, 76}},
-            {187, new byte[] {47, 38, 76}},
-            {188, new byte[] {9, 0, 38}},
-            {189, new byte[] {23, 19, 38}},
-            {190, new byte[] {127, 0, 255}},
-            {191, new byte[] {191, 127, 255}},
-            {192, new byte[] {82, 0, 165}},
-            {193, new byte[] {124, 82, 165}},
-            {194, new byte[] {63, 0, 127}},
-            {195, new byte[] {95, 63, 127}},
-            {196, new byte[] {38, 0, 76}},
-            {197, new byte[] {57, 38, 76}},
-            {198, new byte[] {19, 0, 38}},
-            {199, new byte[] {28, 19, 38}},
-            {200, new byte[] {191, 0, 255}},
-            {201, new byte[] {223, 127, 255}},
-            {202, new byte[] {124, 0, 165}},
-            {203, new byte[] {145, 82, 165}},
-            {204, new byte[] {95, 0, 127}},
-            {205, new byte[] {111, 63, 127}},
-            {206, new byte[] {57, 0, 76}},
-            {207, new byte[] {66, 38, 76}},
-            {208, new byte[] {28, 0, 38}},
-            {209, new byte[] {33, 19, 38}},
-            {210, new byte[] {255, 0, 255}},
-            {211, new byte[] {255, 127, 255}},
-            {212, new byte[] {165, 0, 165}},
-            {213, new byte[] {165, 82, 165}},
-            {214, new byte[] {127, 0, 127}},
-            {215, new byte[] {127, 63, 127}},
-            {216, new byte[] {76, 0, 76}},
-            {217, new byte[] {76, 38, 76}},
-            {218, new byte[] {38, 0, 38}},
-            {219, new byte[] {38, 19, 38}},
-            {220, new byte[] {255, 0, 191}},
-            {221, new byte[] {255, 127, 223}},
-            {222, new byte[] {165, 0, 124}},
-            {223, new byte[] {165, 82, 145}},
-            {224, new byte[] {127, 0, 95}},
-            {225, new byte[] {127, 63, 111}},
-            {226, new byte[] {76, 0, 57}},
-            {227, new byte[] {76, 38, 66}},
-            {228, new byte[] {38, 0, 28}},
-            {229, new byte[] {38, 19, 33}},
-            {230, new byte[] {255, 0, 127}},
-            {231, new byte[] {255, 127, 191}},
-            {232, new byte[] {165, 0, 82}},
-            {233, new byte[] {165, 82, 124}},
-            {234, new byte[] {127, 0, 63}},
-            {235, new byte[] {127, 63, 95}},
-            {236, new byte[] {76, 0, 38}},
-            {237, new byte[] {76, 38, 57}},
-            {238, new byte[] {38, 0, 19}},
-            {239, new byte[] {38, 19, 28}},
-            {240, new byte[] {255, 0, 63}},
-            {241, new byte[] {255, 127, 159}},
-            {242, new byte[] {165, 0, 41}},
-            {243, new byte[] {165, 82, 103}},
-            {244, new byte[] {127, 0, 31}},
-            {245, new byte[] {127, 63, 79}},
-            {246, new byte[] {76, 0, 19}},
-            {247, new byte[] {76, 38, 47}},
-            {248, new byte[] {38, 0, 9}},
-            {249, new byte[] {38, 19, 23}},
-            {250, new byte[] {0, 0, 0}},
-            {251, new byte[] {51, 51, 51}},
-            {252, new byte[] {102, 102, 102}},
-            {253, new byte[] {153, 153, 153}},
-            {254, new byte[] {204, 204, 204}},
-            {255, new byte[] {255, 255, 255}}
-        };
-
-        #endregion
 
         #region private fields
 
@@ -403,7 +141,7 @@ namespace netDxf
         /// </summary>
         public static IReadOnlyDictionary<byte, byte[]> IndexRgb
         {
-            get { return indexRgb; }
+            get { return new AciColorDictionary(); }
         }
 
         #endregion
@@ -431,7 +169,7 @@ namespace netDxf
             this.g = g;
             this.b = b;
             this.useTrueColor = true;
-            this.index = RgbToAci(this.r, this.g, this.b);
+            this.index = LookUpAci(this.r, this.g, this.b);
         }
 
         /// <summary>
@@ -727,7 +465,7 @@ namespace netDxf
             this.g = color.G;
             this.b = color.B;
             this.useTrueColor = true;
-            this.index = RgbToAci(this.r, this.g, this.b);
+            this.index = LookUpAci(this.r, this.g, this.b);
         }
 
         /// <summary>
@@ -774,6 +512,126 @@ namespace netDxf
                 return ByLayer;
 
             return new AciColor(index);
+        }
+
+        /// <summary>
+        /// Searches RGB value in Autocad color palette (ACI).
+        /// </summary>
+        /// <param name="colorIndex">Index of color in ACI palette.</param>
+        /// <returns>
+        /// RGB value: integer with blue in less significant byte,
+        /// green the second byte, and Red the third byte.
+        /// </returns>
+        public static int LookUpRgb(byte colorIndex)
+        {
+            // Autocad returns 0xC5000000 (kForeground) for both - ByLayer and for white/black
+            const int FOREGROUND = unchecked((int)0xC5000000);
+
+            // legacy palette
+            switch (colorIndex)
+            {
+                case 0: return FOREGROUND; // 000-BYBLOCK
+                case 1: return 0x00FF0000; // 001-red
+                case 2: return 0x00FFFF00; // 002-yellow
+                case 3: return 0x0000FF00; // 003-green
+                case 4: return 0x0000FFFF; // 004-cyan
+                case 5: return 0x000000FF; // 005-blue
+                case 6: return 0x00FF00FF; // 006-magenta
+                case 7: return FOREGROUND | 0x00FFFFFF; // 007-white
+                case 8: return 0x00808080; // 008-grey
+                case 9: return 0x00C0C0C0; // 009-lt grey
+            }
+
+            if (colorIndex >= 250)
+            {
+                // grayscale, step HSV value by 16 from 20 to 100% 
+                int c = 255 * (20 + ((colorIndex - 250) << 4)) / 100;
+                return (c << 16) | (c << 8) | c;
+            }
+
+            // perform HSV -> RGB conversion. 
+
+            /*  The chromatic colors.  The  hue  resulting  from  an
+                AutoCAD color 10-249 will be determined by its first
+                two digits, and the saturation and  value  from  the
+                last digit, as follows: 
+            */
+
+            // first two digits - hue degree in range 0-24
+            int h = (colorIndex - 10) / 10;
+
+            // value in 100, 80, 60, 50 or 30% of byte.MaxValue
+            // for each two rows of ACI palette
+            int v = 0;
+
+            // last digit of ACI - HCV value component
+            switch ((colorIndex % 10) >> 1) {
+                case 0: v = 255;            break; // 100%
+                case 1: v = 255 * 80 / 100; break; // 80%
+                case 2: v = 255 * 60 / 100; break; // 60%
+                case 3: v = 255 * 50 / 100; break; // 50%
+                case 4: v = 255 * 30 / 100; break; // 30%
+            }
+
+            int f = (h % 4) << 6; // fraction
+            
+            // saturation: 1 - for even indexes, 1/2 - for odd ones
+            // we will use left shif bitwise division
+            int s = colorIndex & 1;
+
+            int p = (v * (0x100 - (0x100       >> s))) >> 8;
+            int q = (v * (0x100 - (         f  >> s))) >> 8;
+            int t = (v * (0x100 - ((0x100 - f) >> s))) >> 8;
+
+            switch (h >> 2)
+            {
+                case 0: return (v << 16) | (t << 8) | p;
+                case 1: return (q << 16) | (v << 8) | p;
+                case 2: return (p << 16) | (v << 8) | t;
+                case 3: return (p << 16) | (q << 8) | v;
+                case 4: return (t << 16) | (p << 8) | v;
+                case 5: return (v << 16) | (p << 8) | q;
+                default: return -1; // can't happen, just make compiler happy
+            }
+
+        }
+
+        /// <summary>
+        /// Obtains the approximate color index from the RGB components.
+        /// </summary>
+        /// <param name="r">Red component.</param>
+        /// <param name="g">Green component.</param>
+        /// <param name="b">Blue component.</param>
+        /// <returns>The approximate color index from the RGB components</returns>
+        /// <remarks>This conversion will never be accurate.</remarks>
+        public static byte LookUpAci(byte r, byte g, byte b)
+        {
+            //now get color using shortest dist calc and see if it matches
+            int minDist = int.MaxValue;
+            byte match = 0; // this will end up with our answer
+
+            for (int i = 1; i <= byte.MaxValue; ++i)
+            {
+
+                int rgb = LookUpRgb((byte)i);
+                int rDiff = r - (byte)(rgb >> 16);
+                int gDiff = g - (byte)(rgb >> 8);
+                int bDiff = b - (byte)rgb;
+
+                int dist = rDiff * rDiff + gDiff * gDiff + bDiff * bDiff;
+
+                if (dist < minDist)
+                {
+                    match = (byte)i;
+                    minDist = dist;
+
+                    // Exact match, no reason to lookup more
+                    if (minDist == 0)
+                        return match;
+                }
+            }
+
+            return match;
         }
 
         #endregion
@@ -833,36 +691,6 @@ namespace netDxf
                 return false;
 
             return (other.r == this.r) && (other.g == this.g) && (other.b == this.b);
-        }
-
-        #endregion
-
-        #region private methods
-
-        /// <summary>
-        /// Obtains the approximate color index from the RGB components.
-        /// </summary>
-        /// <param name="r">Red component.</param>
-        /// <param name="g">Green component.</param>
-        /// <param name="b">Blue component.</param>
-        /// <returns>The approximate color index from the RGB components</returns>
-        /// <remarks>This conversion will never be accurate.</remarks>
-        private static byte RgbToAci(byte r, byte g, byte b)
-        {
-            double prevDist = double.MaxValue;
-            byte index = 0;
-            foreach (byte key in IndexRgb.Keys)
-            {
-                byte[] color = IndexRgb[key];
-                double dist = Math.Abs(0.3*(r - color[0]) + 0.59*(g - color[1]) + 0.11*(b - color[2]));
-                if (dist < prevDist)
-                {
-                    prevDist = dist;
-                    index = key;
-                }
-            }
-
-            return index;
         }
 
         #endregion

--- a/netDxf/netDxf.csproj
+++ b/netDxf/netDxf.csproj
@@ -76,6 +76,7 @@
     <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AciColor.ColorDictionary.cs" />
     <Compile Include="Blocks\BlockAttributeDefinitionChangeEventArgs.cs" />
     <Compile Include="Collections\DimensionStyleOverrideDictionaryEventArgs.cs" />
     <Compile Include="Collections\DimensionStyleOverrideDictionary.cs" />


### PR DESCRIPTION
AciColor color table is incorrect. The same is with results of RgbToAci function (even with correct ACI table).

* indexRgb ACI dictionary replaced with function LookUpRgb, where most RGB values are calculated;
* for backward compatibility with  added IReadOnlyDictionary AciColor.ColorDictionary for property AciColor.IndexRgb
* private RgbToAci function replaced LookUpAci function with results fully equals to Autocad functionality.