### PR TITLE
Added attribute xData

### DIFF
--- a/netDxf/IO/DxfReader.cs
+++ b/netDxf/IO/DxfReader.cs
@@ -3333,6 +3333,8 @@ namespace netDxf.IO
             double rotation = 0.0;
             Vector3 normal = Vector3.UnitZ;
 
+            List<XData> xData = new List<XData>();
+
             // DxfObject codes
             this.chunk.Next();
             while (this.chunk.Code != 100)
@@ -3394,7 +3396,14 @@ namespace netDxf.IO
                         isVisible = this.chunk.ReadShort() == 0;
                         this.chunk.Next();
                         break;
+                    case 1001:
+                        string appId = this.DecodeEncodedNonAsciiCharacters(this.chunk.ReadString());
+                        XData data = this.ReadXDataRecord(new ApplicationRegistry(appId));
+                        xData.Add(data);
+                        break;
                     default:
+                        if (this.chunk.Code >= 1000 && this.chunk.Code <= 1071)
+                            throw new Exception("The extended data of an entity must start with the application registry code.");
                         this.chunk.Next();
                         break;
                 }
@@ -3542,7 +3551,8 @@ namespace netDxf.IO
                 ObliqueAngle = obliqueAngle,
                 Rotation = rotation
             };
-
+            
+            attribute.XData.AddRange(xData);
             return attribute;
         }
 

--- a/netDxf/IO/DxfWriter.cs
+++ b/netDxf/IO/DxfWriter.cs
@@ -4474,6 +4474,8 @@ namespace netDxf.IO
                     this.chunk.Write(74, (short) 0);
                     break;
             }
+            
+            this.WriteXData(attrib.XData);
         }
 
         private void WriteViewport(Viewport vp)

--- a/netDxf/XDataRecord.cs
+++ b/netDxf/XDataRecord.cs
@@ -33,7 +33,7 @@ namespace netDxf
         #region private fields
 
         private readonly XDataCode code;
-        private readonly object value;
+        private object value;
 
         #endregion
 
@@ -167,7 +167,7 @@ namespace netDxf
         #region public properties
 
         /// <summary>
-        /// Gets or set the XData code.
+        /// Gets the XData code.
         /// </summary>
         /// <remarks>The only valid values are the ones defined in the <see cref="XDataCode">XDataCode</see> class.</remarks>
         public XDataCode Code
@@ -181,6 +181,66 @@ namespace netDxf
         public object Value
         {
             get { return this.value; }
+            set 
+            {
+                if(value == null)
+                    throw new ArgumentNullException(nameof(value));
+
+                switch (this.Code)
+                {
+                    case XDataCode.BinaryData:
+                        if (!(value is byte[]))
+                            throw new ArgumentException("The value of a XDataCode.BinaryData must be a byte array.", nameof(value));
+                        break;
+                    case XDataCode.ControlString:
+                        string v = value as string;
+                        if (string.IsNullOrEmpty(v))
+                            throw new ArgumentException("The value of a XDataCode.ControlString must be a string.", nameof(value));
+                        if (!string.Equals(v, "{") && !string.Equals(v, "}"))
+                            throw new ArgumentException("The only valid values of a XDataCode.ControlString are { or }.", nameof(value));
+                        break;
+                    case XDataCode.DatabaseHandle:
+                        if (!(value is string))
+                            throw new ArgumentException("The value of a XDataCode.DatabaseHandle must be an hexadecimal number.", nameof(value));
+                        long test;
+                        if (!long.TryParse((string) value, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out test))
+                            throw new ArgumentException("The value of a XDataCode.DatabaseHandle must be an hexadecimal number.", nameof(value));
+                        value = test.ToString("X");
+                        break;
+                    case XDataCode.Distance:
+                    case XDataCode.Real:
+                    case XDataCode.RealX:
+                    case XDataCode.RealY:
+                    case XDataCode.RealZ:
+                    case XDataCode.WorldSpacePositionX:
+                    case XDataCode.WorldSpacePositionY:
+                    case XDataCode.WorldSpacePositionZ:
+                    case XDataCode.ScaleFactor:
+                    case XDataCode.WorldDirectionX:
+                    case XDataCode.WorldDirectionY:
+                    case XDataCode.WorldDirectionZ:
+                    case XDataCode.WorldSpaceDisplacementX:
+                    case XDataCode.WorldSpaceDisplacementY:
+                    case XDataCode.WorldSpaceDisplacementZ:
+                        if (!(value is double))
+                            throw new ArgumentException(string.Format("The value of a XDataCode.{0} must be a {1}.", code, typeof (double)), nameof(value));
+                        break;
+                    case XDataCode.Int16:
+                        if (!(value is short))
+                            throw new ArgumentException(string.Format("The value of a XDataCode.{0} must be a {1}.", code, typeof (short)), nameof(value));
+                        break;
+                    case XDataCode.Int32:
+                        if (!(value is int))
+                            throw new ArgumentException(string.Format("The value of a XDataCode.{0} must be an {1}.", code, typeof (int)), nameof(value));
+                        break;
+                    case XDataCode.LayerName:
+                    case XDataCode.String:
+                        if (!(value is string))
+                            throw new ArgumentException(string.Format("The value of a XDataCode.{0} must be a {1}.", code, typeof (string)), nameof(value));
+                        break;
+                }
+                this.value = value;
+            }
         }
 
         #endregion


### PR DESCRIPTION
Attribute Definition inherited DxfObject, ICloneable, and IHasXData.
However, the Attribute Reference inherited DxfObject, and ICloneable.

The Attribute object is missing IHasXData interface. I added this and added the necessary items to the Attribute object so it can use XData. Furthermore, I modified DxfReader and DxfWriter to read and write XData from attributes.