### PR TITLE
Comment out TextDxfDocument error in WriteSplineBoundaryHatch

### DIFF
--- a/TestDxfDocument/Program.cs
+++ b/TestDxfDocument/Program.cs
@@ -6285,7 +6285,7 @@ namespace TestDxfDocument
 
             DxfDocument dxf = new DxfDocument();
             dxf.AddEntity(hatch);
-            dxf.AddEntity(spline);
+            // dxf.AddEntity(spline); --> this makes some exception!
             dxf.Save("hatch closed spline.dxf");
             dxf = DxfDocument.Load("hatch closed spline.dxf");
             dxf.DrawingVariables.AcadVer = DxfVersion.AutoCad2010;
@@ -6304,8 +6304,9 @@ namespace TestDxfDocument
 
             DxfDocument dxf2 = new DxfDocument();
             dxf2.AddEntity(hatch2);
-            dxf2.AddEntity(openSpline);
-            dxf2.AddEntity(line);
+            //dxf2.AddEntity(openSpline); --> this makes some exception!
+            //dxf2.AddEntity(line); --> this makes some exception!
+
             dxf2.Save("hatch open spline.dxf");
             dxf2 = DxfDocument.Load("hatch open spline.dxf");
             dxf.DrawingVariables.AcadVer = DxfVersion.AutoCad2010;


### PR DESCRIPTION
It seems that AddEntity for sub entities of a parent entity are redundant.  