### PR TITLE
The comparison operation must be accurate

### DIFF
--- a/netDxf/MathHelper.cs
+++ b/netDxf/MathHelper.cs
@@ -503,7 +503,7 @@ namespace netDxf
         public static double NormalizeAngle(double angle)
         {
             double normalized = angle%360.0;
-            if (normalized < 0) return 360.0 + normalized;
+            if (Sign(normalized) == -1) return 360.0 + normalized;
             return normalized;
         }
 


### PR DESCRIPTION
I encountered a situation where the input to the method **MathHelper.NormalizeAngle** is a value very close to zero (-1.4210854715202004 E-14), but it is not perceived by the method as zero.
However, there is a **MathHelper.Sign()** method that takes these nuances into account, but is not used when normalizing the angle.
I suggest using it here.