### PR TITLE
Moved the exception for angular units being surveyor units

### DIFF
--- a/netDxf/Entities/DimensionBlock.cs
+++ b/netDxf/Entities/DimensionBlock.cs
@@ -80,8 +80,9 @@ namespace netDxf.Entities
                         dimText = AngleUnitFormat.ToRadians(measure, unitFormat);
                         break;
                     case AngleUnitType.SurveyorUnits:
-                        dimText = AngleUnitFormat.ToDecimal(measure, unitFormat);
-                        break;
+                        throw new ArgumentException("Surveyor's units are not applicable in angular dimensions.");
+                        //dimText = AngleUnitFormat.ToDecimal(measure, unitFormat);
+                        //break;
                 }
             }
             else

--- a/netDxf/Tables/DimensionStyle.cs
+++ b/netDxf/Tables/DimensionStyle.cs
@@ -1048,14 +1048,7 @@ namespace netDxf.Tables
         public AngleUnitType DimAngularUnits
         {
             get { return this.dimaunit; }
-            set
-            {
-                if (value == AngleUnitType.SurveyorUnits)
-                {
-                    throw new ArgumentException("Surveyor's units are not applicable in angular dimensions.");
-                }
-                this.dimaunit = value;
-            }
+            set { this.dimaunit = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
I encountered a DXF with the setting, but no angular measurements (or at least I wasn't writing a DXF). I wanted to be able to read it, so I moved the exception from `DimensionStyle.DimAngularUnits` to `DimensionBlock.FormatDimensionText`. It could be done with a setting, but this way seemed cleanest. Please let me know if you'd like a different approach.