### PR TITLE
Fixed type issue for AltUnitsEnabled

### DIFF
--- a/netDxf/IO/DxfWriter.cs
+++ b/netDxf/IO/DxfWriter.cs
@@ -3790,7 +3790,7 @@ namespace netDxf.IO
                         break;
                     case DimensionStyleOverrideType.AltUnitsEnabled:
                         xdataEntry.XDataRecord.Add(new XDataRecord(XDataCode.Int16, (short) 170));
-                        xdataEntry.XDataRecord.Add(new XDataRecord(XDataCode.Int16, (short) styleOverride.Value));
+                        xdataEntry.XDataRecord.Add(new XDataRecord(XDataCode.Int16, (bool) styleOverride.Value ? (short) 0 : (short) 1));
                         break;
                     case DimensionStyleOverrideType.AltUnitsLengthUnits:
                         writeDIMALTU = true;


### PR DESCRIPTION
It is cast to bool in DxfReader.cs:5927 but DxfWriter expected a short.
Since DimensionStyleOverride.cs:298 clearly expects a bool, changed DxfWriter to accept a bool as well.
Otherwise a System.InvalidCastException will be thrown.