### PR TITLE
fix usage of AltUnitsSuffix and AltUnitsPrefix in DxfReader

### DIFF
--- a/netDxf/IO/DxfReader.cs
+++ b/netDxf/IO/DxfReader.cs
@@ -5695,12 +5695,12 @@ namespace netDxf.IO
                                     string[] altTextPrefixSuffix = GetDimStylePrefixAndSuffix(dimapost, '[', ']');
                                     if (!string.IsNullOrEmpty(altTextPrefixSuffix[0]))
                                     {
-                                        overrides.Add(new DimensionStyleOverride(DimensionStyleOverrideType.DimPrefix, altTextPrefixSuffix[0]));
+                                        overrides.Add(new DimensionStyleOverride(DimensionStyleOverrideType.AltUnitsPrefix, altTextPrefixSuffix[0]));
                                     }
 
                                     if (!string.IsNullOrEmpty(altTextPrefixSuffix[1]))
                                     {
-                                        overrides.Add(new DimensionStyleOverride(DimensionStyleOverrideType.DimSuffix, altTextPrefixSuffix[1]));
+                                        overrides.Add(new DimensionStyleOverride(DimensionStyleOverrideType.AltUnitsSuffix, altTextPrefixSuffix[1]));
                                     }
 
                                     break;


### PR DESCRIPTION
If both, a DimSuffix (DIMPOST) and AltUnitsSuffix (DIMAPOST) are present, a System.ArgumentException would be thrown when adding two overrides with the same type to the dictionary