### PR TITLE
remove pipe from invalid table symbol characters

### DIFF
--- a/netDxf/Tables/TableObject.cs
+++ b/netDxf/Tables/TableObject.cs
@@ -56,7 +56,7 @@ namespace netDxf.Tables
 
         #region private fields
 
-        private static readonly char[] invalidCharacters = { '\\', '/', ':', '*', '?', '"', '<', '>', '|', ';', ',', '=', '`' };
+        private static readonly char[] invalidCharacters = { '\\', '/', ':', '*', '?', '"', '<', '>', ';', ',', '=', '`' };
         private bool reserved;
         private string name;
 


### PR DESCRIPTION
I haven't found any credible documentation for that, but I do have some dxf files which contain pipes in some table names and AutoCad does not complain about that?!
Hence I would like to use this pull request to start a discussion about this topic.