### PR TITLE
Allow zero width

### DIFF
--- a/netDxf/Entities/Attribute.cs
+++ b/netDxf/Entities/Attribute.cs
@@ -334,9 +334,9 @@ namespace netDxf.Entities
             get { return this.width; }
             set
             {
-                if (value <= 0)
+                if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, "The Text width must be greater than zero.");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The Text width must be greater or equal zero.");
                 }
                 this.width = value;
             }

--- a/netDxf/Entities/AttributeDefinition.cs
+++ b/netDxf/Entities/AttributeDefinition.cs
@@ -338,9 +338,9 @@ namespace netDxf.Entities
             get { return this.width; }
             set
             {
-                if (value <= 0)
+                if (value < 0)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(value), value, "The Text width must be greater than zero.");
+                    throw new ArgumentOutOfRangeException(nameof(value), value, "The Text width must be greater or equal zero.");
                 }
                 this.width = value;
             }


### PR DESCRIPTION
Here is another change I had to make to be able to read a wide range of dxf files. The text width turned out to be zero and it's text alignment was set to fit and the two alignment points coincide - which seems odd. I am not sure whether this is the correct way to address this problem, as I am everything but an AutoCad expert.