### PR TITLE
Support .net standard 2.0

### DIFF
--- a/netDxf/netDxf.csproj
+++ b/netDxf/netDxf.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <Version>3.0.0</Version>
     <Authors>Daniel Carvajal</Authors>
     <Owners>haplokuon</Owners>
@@ -41,6 +41,10 @@
   </PropertyGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
+  </ItemGroup>
+	
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />
   </ItemGroup>
   


### PR DESCRIPTION
Is it possible to support .net standard 2.0, just by adding netstandard2.0 to TargetFrameworks in netDxf.csproj?

This will allow you to use all .net framework versions up to .net framework 4.8.