### PR TITLE
PackageId for official netDxf nupkg

### DIFF
--- a/netDxf/netDxf.csproj
+++ b/netDxf/netDxf.csproj
@@ -12,6 +12,7 @@
     <SignAssembly>true</SignAssembly>
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>netDxf.snk</AssemblyOriginatorKeyFile>
+    <PackageId>netDxf-official</PackageId>
     <PackageProjectUrl>https://github.com/haplokuon/netDxf</PackageProjectUrl>
     <RepositoryUrl>https://github.com/haplokuon/netDxf</RepositoryUrl>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>


### PR DESCRIPTION
With this PR the `PackageId` field added to csproj with the name `netDxf-official` that isn't used on nuget as results from this search https://www.nuget.org/packages?q=netDxf

Publish nupkg is pretty simple:
- register your free account to https://www.nuget.org
- create a api key and save to a safe location outside the source tree ( mine is a 46 characters length api key ) ; you can reuse every time to publish new versions and you can revoke and generate new ones from user profile on nuget account.
- do following commands ( replace APIKEY with your api key ):

```sh
cd netDxf/netDxf
dotnet pack -c Release
dotnet nuget push bin/Release/*.nupkg -k APIKEY -s https://api.nuget.org/v3/index.json
```