### PR TITLE
Fix parsing of OCC output

### DIFF
--- a/netDxf/IO/DxfReader.cs
+++ b/netDxf/IO/DxfReader.cs
@@ -10318,9 +10318,15 @@ namespace netDxf.IO
                     this.chunk.Next();
                 }
 
-                string linetypeName = this.DecodeEncodedNonAsciiCharacters(this.chunk.ReadString()); // code 6
-                Linetype linetype = this.GetLinetype(linetypeName);
-                this.chunk.Next();
+                // code 6 expected now for line type
+                // if not found (missing in occ ouput), use defaults:
+                Linetype linetype = Linetype.Continuous;
+                if (this.chunk.Code == 6)
+                {
+                    string linetypeName = this.DecodeEncodedNonAsciiCharacters(this.chunk.ReadString()); // code 6
+                    linetype = this.GetLinetype(linetypeName);
+                    this.chunk.Next();
+                }
 
                 MLineStyleElement element = new MLineStyleElement(offset)
                 {

--- a/netDxf/IO/DxfReader.cs
+++ b/netDxf/IO/DxfReader.cs
@@ -10319,7 +10319,7 @@ namespace netDxf.IO
                 }
 
                 // code 6 expected now for line type
-                // if not found (missing in occ ouput), use defaults:
+                // if not found, use defaults:
                 Linetype linetype = Linetype.Continuous;
                 if (this.chunk.Code == 6)
                 {


### PR DESCRIPTION
DXF output from OpenCascade is usually not parsable due to missing dimension linetype. This fix allow to parse the document using CONTINUOUS linetype as default fallback.