### PR TITLE
Reading MLeaders and OLE objects

### DIFF
--- a/netDxf/Collections/MLeaderStyles.cs
+++ b/netDxf/Collections/MLeaderStyles.cs
@@ -1,0 +1,174 @@
+
+#region netDxf library licensed under the MIT License
+//
+//                       netDxf library
+// Copyright (c) 2019-2021 Daniel Carvajal (haplokuon@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+
+using netDxf.Objects;
+using netDxf.Tables;
+
+namespace netDxf.Collections;
+
+/// <summary>
+/// Represents a collection of MLeader styles.
+/// </summary>
+public sealed class MLeaderStyles :
+    TableObjects<MLeaderStyle>
+{
+    #region constructor
+
+    internal MLeaderStyles(DxfDocument document)
+        : this(document, null)
+    {
+    }
+
+    internal MLeaderStyles(DxfDocument document, string handle)
+        : base(document, DxfObjectCode.MLineStyleDictionary, handle)
+    {
+    }
+
+    #endregion
+
+    #region override methods
+
+    /// <summary>
+    /// Adds a Mleader style to the list.
+    /// </summary>
+    /// <param name="style"><see cref="MLeaderStyle">MLeaderStyle</see> to add to the list.</param>
+    /// <param name="assignHandle">Specifies if a handle needs to be generated for the multiline style parameter.</param>
+    /// <returns>
+    /// If a MLeader style already exists with the same name as the instance that is being added the method returns the existing multiline style,
+    /// if not it will return the new MLeader style.
+    /// </returns>
+    internal override MLeaderStyle Add(MLeaderStyle style, bool assignHandle)
+    {
+        if (style == null)
+        {
+            throw new ArgumentNullException(nameof(style));
+        }
+
+        if (this.list.TryGetValue(style.Name, out var add))
+        {
+            return add;
+        }
+
+        if (assignHandle || string.IsNullOrEmpty(style.Handle))
+        {
+            this.Owner.NumHandles = style.AssignHandle(this.Owner.NumHandles);
+        }
+
+        this.list.Add(style.Name, style);
+        this.references.Add(style.Name, new List<DxfObject>());
+
+        style.Owner = this;
+
+        style.NameChanged += this.Item_NameChanged;
+
+        this.Owner.AddedObjects.Add(style.Handle, style);
+
+        return style;
+    }
+
+
+    public override bool Remove(string name)
+    {
+        return this.Remove(this[name]);
+    }
+
+    public override bool Remove(MLeaderStyle item)
+    {
+        if (item == null)
+        {
+            return false;
+        }
+
+        if (!this.Contains(item))
+        {
+            return false;
+        }
+
+        if (item.IsReserved)
+        {
+            return false;
+        }
+
+        if (this.references[item.Name].Count != 0)
+        {
+            return false;
+        }
+
+        this.Owner.AddedObjects.Remove(item.Handle);
+        this.references.Remove(item.Name);
+        this.list.Remove(item.Name);
+
+        item.Handle = null;
+        item.Owner = null;
+
+        item.NameChanged -= this.Item_NameChanged;
+
+        return true;
+    }
+
+    #endregion
+
+    #region MLineStyle events
+
+    private void Item_NameChanged(TableObject sender, TableObjectChangedEventArgs<string> e)
+    {
+        if (this.Contains(e.NewValue))
+        {
+            throw new ArgumentException("There is already another MLeader style with the same name.");
+        }
+
+        this.list.Remove(sender.Name);
+        this.list.Add(e.NewValue, (MLeaderStyle)sender);
+
+        var refs = this.references[sender.Name];
+        this.references.Remove(sender.Name);
+        this.references.Add(e.NewValue, refs);
+    }
+
+    private void MLineStyle_ElementLinetypeChanged(MLeaderStyle sender, TableObjectChangedEventArgs<Linetype> e)
+    {
+        this.Owner.Linetypes.References[e.OldValue.Name].Remove(sender);
+
+        e.NewValue = this.Owner.Linetypes.Add(e.NewValue);
+        this.Owner.Linetypes.References[e.NewValue.Name].Add(sender);
+    }
+
+    private void MLineStyle_ElementAdded(MLeaderStyle sender, MLineStyleElementChangeEventArgs e)
+    {
+        e.Item.Linetype = this.Owner.Linetypes.Add(e.Item.Linetype);
+        this.Owner.Linetypes.References[e.Item.Linetype.Name].Add(sender);
+    }
+
+    private void MLineStyle_ElementRemoved(MLeaderStyle sender, MLineStyleElementChangeEventArgs e)
+    {
+        this.Owner.Linetypes.References[e.Item.Linetype.Name].Remove(sender);
+    }
+
+    #endregion
+}

--- a/netDxf/DxfDocument.cs
+++ b/netDxf/DxfDocument.cs
@@ -33,6 +33,7 @@ using netDxf.Header;
 using netDxf.IO;
 using netDxf.Objects;
 using netDxf.Tables;
+using netDxf.Entities.MLeader;
 using Attribute = netDxf.Entities.Attribute;
 
 namespace netDxf
@@ -89,6 +90,7 @@ namespace netDxf
         private Groups groups;
         private Layouts layouts;
         private RasterVariables rasterVariables;
+        private MLeaderStyles mleaderStyles;
 
         #endregion
 
@@ -468,6 +470,14 @@ namespace netDxf
         {
             get { return this.entities; }
         }
+
+
+        public MLeaderStyles MLeaderStyles
+        {
+            get { return this.mleaderStyles; }
+            internal set { this.mleaderStyles = value; }
+        }
+
 
         #endregion
 
@@ -976,6 +986,21 @@ namespace netDxf
                     viewport.ClippingBoundaryAdded += this.Viewport_ClippingBoundaryAdded;
                     viewport.ClippingBoundaryRemoved += this.Viewport_ClippingBoundaryRemoved;
                     break;
+                case EntityType.MLeader:
+                    var mleader = (MLeader)entity;
+                    if (mleader.StyleHandle is not null)
+                    {
+                        foreach (var style in this.MLeaderStyles)
+                        {
+                            if (style.Handle == mleader.StyleHandle)
+                            {
+                                mleader.MLeaderStyle = style;
+                                break;
+                            }
+                        }
+                    }
+                    break;
+
                 default:
                     throw new ArgumentException("The entity " + entity.Type + " is not implemented or unknown.");
             }
@@ -1367,6 +1392,7 @@ namespace netDxf
             this.underlayPdfDefs = new UnderlayPdfDefinitions(this);
             this.groups = new Groups(this);
             this.layouts = new Layouts(this);
+            this.mleaderStyles = new MLeaderStyles(this);
 
             //add default viewport (the active viewport is automatically added when the collection is created, is the only one supported)
             //this.vports.Add(VPort.Active);

--- a/netDxf/DxfDocument.cs
+++ b/netDxf/DxfDocument.cs
@@ -1200,6 +1200,8 @@ namespace netDxf
                     viewport.ClippingBoundaryRemoved -= this.Viewport_ClippingBoundaryRemoved;
 
                     break;
+                case EntityType.Ole2Frame:
+                    break;
                 default:
                     throw new ArgumentException("The entity " + entity.Type + " is not implemented or unknown");
             }

--- a/netDxf/DxfObjectCode.cs
+++ b/netDxf/DxfObjectCode.cs
@@ -512,5 +512,9 @@ namespace netDxf
         /// MLeader style.
         /// </summary>
         public const string MLeaderStyle = "MLEADERSTYLE";
+        /// <summary>
+        /// Ole2Frame.
+        /// </summary>
+        public const string Ole2FrameSection = "OLE2FRAME";
     }
 }

--- a/netDxf/DxfObjectCode.cs
+++ b/netDxf/DxfObjectCode.cs
@@ -354,6 +354,15 @@ namespace netDxf
         /// MLine.
         /// </summary>
         public const string MLine = "MLINE";
+        /// <summary>
+        /// MLeader styles as table.
+        /// </summary>
+        public const string MLeaderStyleTable = "MLEADERSTYLE";
+        
+        /// <summary>
+        /// MLeader.
+        /// </summary>
+        public const string MLeader = "MULTILEADER";
 
         /// <summary>
         /// 3d face.
@@ -499,5 +508,9 @@ namespace netDxf
         /// Layouts.
         /// </summary>
         public const string Layout = "LAYOUT";
+        /// <summary>
+        /// MLeader style.
+        /// </summary>
+        public const string MLeaderStyle = "MLEADERSTYLE";
     }
 }

--- a/netDxf/Entities/EntityType.cs
+++ b/netDxf/Entities/EntityType.cs
@@ -30,6 +30,12 @@ namespace netDxf.Entities
     /// </summary>
     public enum EntityType
     {
+        
+        /// <summary>
+        /// MLeader entity.
+        /// </summary>
+        MLeader,
+        
         /// <summary>
         /// Arc entity.
         /// </summary>

--- a/netDxf/Entities/EntityType.cs
+++ b/netDxf/Entities/EntityType.cs
@@ -179,6 +179,10 @@ namespace netDxf.Entities
         /// <summary>
         /// XLine entity.
         /// </summary>
-        XLine
+        XLine,
+        /// <summary>
+        /// Ole2Frame entity.
+        /// </summary>
+        Ole2Frame
     }
 }

--- a/netDxf/Entities/MLeader/InsertedData/BlockData.cs
+++ b/netDxf/Entities/MLeader/InsertedData/BlockData.cs
@@ -1,0 +1,92 @@
+using System.Collections.Generic;
+
+using netDxf.IO;
+
+namespace netDxf.Entities.MLeader.InsertedData;
+
+public class BlockData : IMLeaderInsertedContent
+{
+
+    // 341: "block_record_handle",
+    // 14: "extrusion",
+    // 15: "insert",
+    // 16: "scale",
+    // 46: "rotation",
+    // 93: "color",
+
+    public string? BlockRecordHandle;
+    public Vector3 Extrusion = Vector3.UnitZ;
+    public Vector3 Insert = Vector3.Zero;
+    public Vector3 Scale = new(1, 1, 1);
+    public double Rotation; //in radians
+    public int Color = -1056964608;
+
+    // The transformation matrix is stored in transposed order
+    private readonly List<double> _matrix = new();
+
+    bool IMLeaderInsertedContent.ParseTag(ICodeValueReader tag)
+    {
+        switch (tag.Code)
+        {
+            case 341:
+                BlockRecordHandle = tag.ReadString();
+                break;
+            case 14:
+                Extrusion.X = tag.ReadDouble();
+                break;
+            case 24:
+                Extrusion.Y = tag.ReadDouble();
+                break;
+            case 34:
+                Extrusion.Z = tag.ReadDouble();
+                break;
+            case 15:
+                Insert.X = tag.ReadDouble();
+                break;
+            case 25:
+                Insert.Y = tag.ReadDouble();
+                break;
+            case 35:
+                Insert.Z = tag.ReadDouble();
+                break;
+            case 16:
+                Scale.X = tag.ReadDouble();
+                break;
+            case 26:
+                Scale.Y = tag.ReadDouble();
+                break;
+            case 36:
+                Scale.Z = tag.ReadDouble();
+                break;
+            case 47:
+                _matrix.Add(tag.ReadDouble());
+                break;
+            case 46:
+                Rotation = tag.ReadDouble();
+                break;
+            case 93:
+                Color = tag.ReadInt();
+                break;
+            default:
+                return false;
+        }
+        //return True if data belongs to block else False (end of block section)
+        return true;
+    }
+
+    public BlockData Clone()
+    {
+        return new BlockData()
+        {
+            BlockRecordHandle = BlockRecordHandle,
+            Extrusion = new Vector3(Extrusion.X, Extrusion.Y, Extrusion.Z),
+            Insert = new Vector3(Insert.X, Insert.Y, Insert.Z),
+            Scale = new Vector3(Scale.X, Scale.Y, Scale.Z),
+            Rotation = Rotation,
+            Color = Color,
+        };
+    }
+}
+
+
+

--- a/netDxf/Entities/MLeader/InsertedData/IMLeaderInsertedContent.cs
+++ b/netDxf/Entities/MLeader/InsertedData/IMLeaderInsertedContent.cs
@@ -1,0 +1,9 @@
+using netDxf.IO;
+
+namespace netDxf.Entities.MLeader.InsertedData;
+
+internal interface IMLeaderInsertedContent
+{
+    internal bool ParseTag(ICodeValueReader tag);
+
+}

--- a/netDxf/Entities/MLeader/InsertedData/MTextData.cs
+++ b/netDxf/Entities/MLeader/InsertedData/MTextData.cs
@@ -1,0 +1,203 @@
+using System.Collections.Generic;
+
+using netDxf.IO;
+using netDxf.Tables;
+
+namespace netDxf.Entities.MLeader.InsertedData;
+
+public class MTextData : IMLeaderInsertedContent
+{
+
+    // 304: "default_content",
+    // 11: "extrusion",
+    // 340: "style_handle",
+    // 12: "insert",
+    // 13: "text_direction",
+    // 42: "rotation",
+    // 43: "width",
+    // 44: "defined_height",
+    // 45: "line_spacing_factor",
+    // 170: "line_spacing_style",
+    // 90: "color",
+    // 171: "alignment",
+    // 172: "flow_direction",
+    // 91: "bg_color",
+    // 141: "bg_scale_factor",
+    // 92: "bg_transparency",
+    // 291: "use_window_bg_color",
+    // 292: "has_bg_fill",
+    // 173: "column_type",
+    // 293: "use_auto_height",
+    // 142: "column_width",
+    // 143: "column_gutter_width",
+    // 294: "column_flow_reversed",
+    // 144: "column_sizes",  # multiple values
+    // 295: "use_word_break",
+
+    public string DefaultContent = string.Empty;
+    public Vector3 Extrusion = Vector3.UnitZ;
+    public string StyleHandle = "0";  //handle of TextStyle() table entry
+    public Vector3 Insert = Vector3.Zero;
+    public Vector3 TextDirection = Vector3.UnitX; // text direction
+    public double Rotation; //In radians
+    public double Width; //MText width, not scaled
+    public double DefinedHeight; //defined column height, not scaled
+    public double LineSpacingFactor = 1.0;
+    public short LineSpacingStyle = 1; //1=at least, 2=exactly
+    public int Color = -1056964608;
+    public MTextDataAlignment Alignment = MTextDataAlignment.Left; //1=left, 2=center, 3=right
+    public short FlowDirection = 1; //1=horiz, 3=vert, 6=by style
+    public int BgColor = -939524096;
+    public double BgScaleFactor = 1.5;
+    public int BgTransparency = 1;
+    public bool UseWindowBgColor;
+    public bool HasBgFill;
+    public short ColumnType = 1; //Unknown values
+    public bool UseAutoHeight;
+    public double ColumnWidth; //NotScaled
+    public double ColumnGutterWidth; //NotScaled
+    public bool ColumnFlowReversed;
+    public List<double> ColumnSizes = new(); // Heights? Not scaled
+    public bool UseWordBreak = true;
+
+    public TextStyle? TextStyle;  //Updated in DxfReader
+
+    bool IMLeaderInsertedContent.ParseTag(ICodeValueReader tag)
+    {
+        switch (tag.Code)
+        {
+            case 144:
+                ColumnSizes.Add(tag.ReadDouble());
+                break;
+            case 304:
+                DefaultContent = tag.ReadString();
+                break;
+            case 11:
+                Extrusion.X = tag.ReadDouble();
+                break;
+            case 21:
+                Extrusion.Y = tag.ReadDouble();
+                break;
+            case 31:
+                Extrusion.Z = tag.ReadDouble();
+                break;
+            case 340:
+                StyleHandle = tag.ReadString();
+                break;
+            case 12:
+                Insert.X = tag.ReadDouble();
+                break;
+            case 22:
+                Insert.Y = tag.ReadDouble();
+                break;
+            case 32:
+                Insert.Z = tag.ReadDouble();
+                break;
+            case 13:
+                TextDirection.X = tag.ReadDouble();
+                break;
+            case 23:
+                TextDirection.Y = tag.ReadDouble();
+                break;
+            case 33:
+                TextDirection.Z = tag.ReadDouble();
+                break;
+            case 42:
+                Rotation = tag.ReadDouble();
+                break;
+            case 43:
+                Width = tag.ReadDouble();
+                break;
+            case 44:
+                DefinedHeight = tag.ReadDouble();
+                break;
+            case 45:
+                LineSpacingFactor = tag.ReadDouble();
+                break;
+            case 170:
+                LineSpacingStyle = tag.ReadShort();
+                break;
+            case 90:
+                Color = tag.ReadInt();
+                break;
+            case 171:
+                Alignment = (MTextDataAlignment)tag.ReadShort();
+                break;
+            case 172:
+                FlowDirection = tag.ReadShort();
+                break;
+            case 91:
+                BgColor = tag.ReadInt();
+                break;
+            case 141:
+                BgScaleFactor = tag.ReadDouble();
+                break;
+            case 92:
+                BgTransparency = tag.ReadInt();
+                break;
+            case 291:
+                UseWindowBgColor = tag.ReadBool();
+                break;
+            case 292:
+                HasBgFill = tag.ReadBool();
+                break;
+            case 173:
+                ColumnType = tag.ReadShort();
+                break;
+            case 293:
+                UseAutoHeight = tag.ReadBool();
+                break;
+            case 142:
+                ColumnWidth = tag.ReadDouble();
+                break;
+            case 143:
+                ColumnGutterWidth = tag.ReadDouble();
+                break;
+            case 294:
+                ColumnFlowReversed = tag.ReadBool();
+                break;
+            case 295:
+                UseWordBreak = tag.ReadBool();
+                break;
+            default:
+                return false;
+        }
+        //return True if data belongs to MText else False (end of Mtext section)
+        return true;
+
+    }
+
+
+
+    public MTextData Clone()
+    {
+        return new MTextData()
+        {
+            DefaultContent = DefaultContent,
+            Extrusion = new Vector3(Extrusion.X, Extrusion.Y, Extrusion.Z),
+            StyleHandle = StyleHandle,
+            Insert = new Vector3(Insert.X, Insert.Y, Insert.Z),
+            TextDirection = new Vector3(TextDirection.X, TextDirection.Y, TextDirection.Z),
+            Rotation = Rotation,
+            Width = Width,
+            DefinedHeight = DefinedHeight,
+            LineSpacingFactor = LineSpacingFactor,
+            LineSpacingStyle = LineSpacingStyle,
+            Color = Color,
+            Alignment = Alignment,
+            FlowDirection = FlowDirection,
+            BgColor = BgColor,
+            BgScaleFactor = BgScaleFactor,
+            BgTransparency = BgTransparency,
+            UseWindowBgColor = UseWindowBgColor,
+            HasBgFill = HasBgFill,
+            ColumnType = ColumnType,
+            UseAutoHeight = UseAutoHeight,
+            ColumnWidth = ColumnWidth,
+            ColumnGutterWidth = ColumnGutterWidth,
+            ColumnFlowReversed = ColumnFlowReversed,
+            ColumnSizes = ColumnSizes,
+            UseWordBreak = UseWordBreak
+        };
+    }
+}

--- a/netDxf/Entities/MLeader/InsertedData/MTextDataAlignment.cs
+++ b/netDxf/Entities/MLeader/InsertedData/MTextDataAlignment.cs
@@ -1,0 +1,8 @@
+namespace netDxf.Entities.MLeader.InsertedData;
+
+public enum MTextDataAlignment
+{
+    Left = 1,
+    Center = 2,
+    Right = 3
+}

--- a/netDxf/Entities/MLeader/MLeader.cs
+++ b/netDxf/Entities/MLeader/MLeader.cs
@@ -1,0 +1,310 @@
+using System;
+using System.Collections.Generic;
+
+using netDxf.Entities.MLeader.MLeaderGeometry;
+using netDxf.IO;
+using netDxf.Objects;
+
+namespace netDxf.Entities.MLeader;
+
+/// <summary>
+/// Represents a Mleader <see cref="EntityObject">entity</see>.
+/// </summary>
+/// How to render MLEADER: https://atlight.github.io/formats/dxf-leader.html
+public class MLeader :
+    EntityObject
+{
+
+    public MLeaderContext Context = new();
+
+    public short Version = 2;
+    public string? StyleHandle;
+    public MLeaderType LeaderType = MLeaderType.StraightLine;
+
+    public int LeaderLineColor = -1056964608;
+    public string? LeaderLinetypeHandle;
+    public short LeaderLineweight = -2;
+    public bool HasLanding = true;
+    public bool HasDogLeg = true;
+    public double DogLegLenght = 8;
+    public string? ArrowHeadHandle;
+    public double ArrowHeadSize = 4;
+    public MLeaderContentType ContentType = MLeaderContentType.MTextContent;
+
+    //====works for MTextData=====// THIS DATA IS DUPLICATED?! Can be found also in Context tags
+    public string? TextStyleHandle;
+    public short TextLeftAttachemntType = 1;
+    public int TextRightAttachmentType = 1;
+    public short TextAngleType = 1;
+    public short TextAlignmentType = 2;
+    public int TextColor = -1056964608;
+    public bool HasTextFrame;
+    public bool IsTextDirectionNegative;
+    public short TextIPEAlign;
+    public short TextAttachmentPoint = 1;
+    public double Scale = 1;
+    public short TextAttachmentDirection;
+    public short TextBottomAttachmentType = 9;
+    public short TextTopAttachmentType = 9;
+    public bool LeaderExtendToText;
+    //====works for BlockData =====// THIS DATA IS DUPLICATED?! Can be found also in Context tags
+    public string? BlockRecordHandle;
+    public int BlockColor = -1056964608;
+    public Vector3 BlockScaleVector = new(1, 1, 1);
+    public double BlockRotation;
+    public short BlockConnectionType;
+    public bool IsAnnotative;
+    // ===== //
+
+    public MLeaderStyle MLeaderStyle; //APPLIED IN POSTPROCESSING ( SEE DxfReader)
+
+    public MLeader() : base(EntityType.MLeader, DxfObjectCode.MLeader)
+    {
+
+    }
+
+    internal static MLeader Load(List<ICodeValueReader> normalTags, List<object> contextTags)
+    {
+        var mleader = new MLeader();
+
+        mleader.Context = MLeaderContext.Load(contextTags);
+
+        foreach (var tag in normalTags)
+        {
+            switch (tag.Code)
+            {
+                case 270:
+                    {
+                        mleader.Version = tag.ReadShort();
+                        break;
+                    }
+                case 340:
+                    {
+                        mleader.StyleHandle = tag.ReadString();
+                        break;
+                    }
+                case 170:
+                    {
+                        mleader.LeaderType = (MLeaderType)tag.ReadShort();
+                        break;
+                    }
+                case 91:
+                    {
+                        mleader.LeaderLineColor = tag.ReadInt();
+                        break;
+                    }
+                case 341:
+                    {
+                        mleader.LeaderLinetypeHandle = tag.ReadString();
+                        break;
+                    }
+                case 171:
+                    {
+                        mleader.LeaderLineweight = tag.ReadShort();
+                        break;
+                    }
+                case 290:
+                    {
+                        mleader.HasLanding = tag.ReadBool();
+                        break;
+                    }
+                case 291:
+                    {
+                        mleader.HasDogLeg = tag.ReadBool();
+                        break;
+                    }
+                case 41:
+                    {
+                        mleader.DogLegLenght = tag.ReadDouble();
+                        break;
+                    }
+                case 342:
+                    {
+                        mleader.ArrowHeadHandle = tag.ReadString();
+                        break;
+                    }
+                case 42:
+                    {
+                        mleader.ArrowHeadSize = tag.ReadDouble();
+                        break;
+                    }
+                case 172:
+                    {
+                        mleader.ContentType = (MLeaderContentType)tag.ReadShort();
+                        break;
+                    }
+                case 343:
+                    {
+                        mleader.StyleHandle = tag.ReadString();
+                        break;
+                    }
+                case 173:
+                    {
+                        mleader.TextLeftAttachemntType = tag.ReadShort();
+                        break;
+                    }
+                case 95:
+                    {
+                        mleader.TextRightAttachmentType = tag.ReadInt();
+                        break;
+                    }
+                case 174:
+                    {
+                        mleader.TextAngleType = tag.ReadShort();
+                        break;
+                    }
+                case 175:
+                    {
+                        mleader.TextAlignmentType = tag.ReadShort();
+                        break;
+                    }
+                case 92:
+                    {
+                        mleader.TextColor = tag.ReadInt();
+                        break;
+                    }
+                case 292:
+                    {
+                        mleader.HasTextFrame = tag.ReadBool();
+                        break;
+                    }
+                case 344:
+                    {
+                        mleader.BlockRecordHandle = tag.ReadString();
+                        break;
+                    }
+                case 93:
+                    {
+                        mleader.BlockColor = tag.ReadInt();
+                        break;
+                    }
+                case 10:
+                    {
+                        mleader.BlockScaleVector.X = tag.ReadDouble();
+                        break;
+                    }
+                case 20:
+                    {
+                        mleader.BlockScaleVector.Y = tag.ReadDouble();
+                        break;
+                    }
+                case 30:
+                    {
+                        mleader.BlockScaleVector.Z = tag.ReadDouble();
+                        break;
+                    }
+                case 43:
+                    {
+                        mleader.BlockRotation = tag.ReadDouble();
+                        break;
+                    }
+                case 176:
+                    {
+                        mleader.BlockConnectionType = tag.ReadShort();
+                        break;
+                    }
+                case 293:
+                    {
+                        mleader.IsAnnotative = tag.ReadBool();
+                        break;
+                    }
+                case 294:
+                    {
+                        mleader.IsTextDirectionNegative = tag.ReadBool();
+                        break;
+                    }
+                case 178:
+                    {
+                        mleader.TextIPEAlign = tag.ReadShort();
+                        break;
+                    }
+                case 179:
+                    {
+                        mleader.TextAttachmentPoint = tag.ReadShort();
+                        break;
+                    }
+                case 45:
+                    {
+                        mleader.Scale = tag.ReadDouble();
+                        break;
+                    }
+                case 271:
+                    {
+                        mleader.TextAttachmentDirection = tag.ReadShort();
+                        break;
+                    }
+                case 272:
+                    {
+                        mleader.TextBottomAttachmentType = tag.ReadShort();
+                        break;
+                    }
+                case 273:
+                    {
+                        mleader.TextTopAttachmentType = tag.ReadShort();
+                        break;
+                    }
+                case 295:
+                    {
+                        mleader.LeaderExtendToText = tag.ReadBool();
+                        break;
+                    }
+            }
+        }
+
+
+        return mleader;
+    }
+
+
+
+    public override void TransformBy(Matrix3 transformation, Vector3 translation)
+    {
+        throw new NotImplementedException();
+    }
+
+
+
+    public override object Clone()
+    {
+        return new MLeader()
+        {
+            Context = Context.Clone(),
+            Version = Version,
+            StyleHandle = StyleHandle,
+            LeaderType = LeaderType,
+            LeaderLineColor = LeaderLineColor,
+            LeaderLinetypeHandle = LeaderLinetypeHandle,
+            LeaderLineweight = LeaderLineweight,
+            HasLanding = HasLanding,
+            HasDogLeg = HasDogLeg,
+            DogLegLenght = DogLegLenght,
+            ArrowHeadHandle = ArrowHeadHandle,
+            ArrowHeadSize = ArrowHeadSize,
+            ContentType = ContentType,
+            TextStyleHandle = TextStyleHandle,
+            TextLeftAttachemntType = TextLeftAttachemntType,
+            TextAngleType = TextAngleType,
+            TextAlignmentType = TextAlignmentType,
+            TextColor = TextColor,
+            HasTextFrame = HasTextFrame,
+            IsTextDirectionNegative = IsTextDirectionNegative,
+            TextIPEAlign = TextIPEAlign,
+
+            TextAttachmentPoint = TextAttachmentPoint,
+            Scale = Scale,
+            TextAttachmentDirection = TextAttachmentDirection,
+            TextBottomAttachmentType = TextBottomAttachmentType,
+            TextTopAttachmentType = TextTopAttachmentType,
+            LeaderExtendToText = LeaderExtendToText,
+            BlockRecordHandle = BlockRecordHandle,
+            BlockColor = BlockColor,
+            BlockScaleVector = BlockScaleVector,
+
+            BlockRotation = BlockRotation,
+            BlockConnectionType = BlockConnectionType,
+            IsAnnotative = IsAnnotative
+        };
+    }
+
+}
+

--- a/netDxf/Entities/MLeader/MLeaderContentType.cs
+++ b/netDxf/Entities/MLeader/MLeaderContentType.cs
@@ -1,0 +1,11 @@
+namespace netDxf.Entities.MLeader;
+
+
+public enum MLeaderContentType
+{
+    None = 0,
+    BlockContent = 1,
+    MTextContent = 2,
+    ToleranceContent = 3
+}
+

--- a/netDxf/Entities/MLeader/MLeaderGeometry/LeaderData.cs
+++ b/netDxf/Entities/MLeader/MLeaderGeometry/LeaderData.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+
+using netDxf.IO;
+
+namespace netDxf.Entities.MLeader.MLeaderGeometry;
+
+public class LeaderData
+{
+    public List<LeaderLine> Lines = new();
+    public bool HasLastLeaderLine;  // group code 290, in AutoCAD the leader is invisible if set to 0, BricsCAD ignores this flag
+    public bool HasDogLegVector;  // group code 291,
+    public Vector3 LastLeaderPoint = Vector3.Zero; // group code (10, 20, 30) in WCS
+    public Vector3 DogLegVector = Vector3.UnitX; // group code (11, 21, 31) in WCS
+    public double DogLegLenght = 1.0; //group code 40
+    public int Index; //group code 90
+    public int AttachmentDirection; //group code 271
+    public List<Vector3> Breaks = new(); // group code 12, 13 - multiple breaks possible!
+
+    public static LeaderData Load(List<object> tags)
+    {
+        var firstTag = tags[0];
+
+        if (!(firstTag is ICodeValueReader tcv && tcv.Code == DxfReader.START_LEADER && (string)tcv.Value == DxfReader.LEADER_STR))
+        {
+            if (firstTag is ICodeValueReader t)
+            {
+                throw new Exception($"Cannot load LeaderData - wrong start code: {t.Code} - {t.Value}");
+            }
+            else
+            {
+                throw new Exception("Cannot load LeaderData - wrong start code");
+            }
+
+        }
+
+
+        var firstBreakVectorFound = false;
+        var secondBreakVectorFound = false;
+        var firstBreakVector = Vector3.Zero;
+        var secondBreakVector = Vector3.Zero;
+
+        var leaderData = new LeaderData();
+
+
+        foreach (var t in tags)
+        {
+            switch (t)
+            {
+                case List<object> tList:
+                    leaderData.Lines.Add(LeaderLine.Load(tList));
+                    break;
+                case ICodeValueReader tagCodeValue:
+                    switch (tagCodeValue.Code)
+                    {
+                        case 10:
+                            leaderData.LastLeaderPoint.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 20:
+                            leaderData.LastLeaderPoint.Y = tagCodeValue.ReadDouble();
+                            break;
+                        case 30:
+                            leaderData.LastLeaderPoint.Z = tagCodeValue.ReadDouble();
+                            break;
+                        case 11:
+                            leaderData.DogLegVector.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 21:
+                            leaderData.DogLegVector.Y = tagCodeValue.ReadDouble();
+                            break;
+                        case 31:
+
+                            leaderData.DogLegVector.Z = tagCodeValue.ReadDouble();
+                            break;
+                        case 12:
+
+                            firstBreakVectorFound = true;
+                            firstBreakVector.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 22:
+                            firstBreakVectorFound = true;
+                            firstBreakVector.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 32:
+                            firstBreakVectorFound = true;
+                            firstBreakVector.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 13:
+
+                            secondBreakVectorFound = true;
+                            secondBreakVector.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 23:
+                            secondBreakVectorFound = true;
+                            secondBreakVector.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 33:
+                            secondBreakVectorFound = true;
+                            secondBreakVector.X = tagCodeValue.ReadDouble();
+                            break;
+                        case 290:
+                            leaderData.HasLastLeaderLine = tagCodeValue.ReadBool();
+                            break;
+                        case 291:
+                            leaderData.HasDogLegVector = tagCodeValue.ReadBool();
+                            break;
+                        case 40:
+                            leaderData.DogLegLenght = tagCodeValue.ReadDouble();
+                            break;
+                        case 271:
+                            leaderData.AttachmentDirection = tagCodeValue.ReadInt();
+                            break;
+                    }
+
+                    break;
+                default:
+                    throw new Exception("Something wrong with types!");
+                    break;
+            }
+        }
+
+        if (firstBreakVectorFound)
+        {
+            leaderData.Breaks.Add(firstBreakVector);
+        }
+        if (secondBreakVectorFound)
+        {
+            leaderData.Breaks.Add(secondBreakVector);
+        }
+
+        return leaderData;
+    }
+
+    public LeaderData Clone()
+    {
+        var clonedLines = new List<LeaderLine>() { };
+        var clonedBreaks = new List<Vector3>() { };
+
+        foreach (var line in Lines)
+        {
+            clonedLines.Add(line.Clone());
+        }
+
+        foreach (var breakPoint in Breaks)
+        {
+            clonedBreaks.Add(new Vector3(breakPoint.X, breakPoint.Y, breakPoint.Z));
+        }
+
+        return new LeaderData()
+        {
+            Lines = clonedLines,
+            HasLastLeaderLine = HasLastLeaderLine,
+            HasDogLegVector = HasDogLegVector,
+            LastLeaderPoint = new Vector3(LastLeaderPoint.X, LastLeaderPoint.Y, LastLeaderPoint.Z),
+            DogLegVector = new Vector3(DogLegVector.X, DogLegVector.Y, DogLegVector.Z),
+            DogLegLenght = DogLegLenght,
+            Index = Index,
+            AttachmentDirection = AttachmentDirection,
+            Breaks = clonedBreaks,
+
+        };
+    }
+
+}

--- a/netDxf/Entities/MLeader/MLeaderGeometry/LeaderLine.cs
+++ b/netDxf/Entities/MLeader/MLeaderGeometry/LeaderLine.cs
@@ -1,0 +1,109 @@
+using System;
+using System.Collections.Generic;
+
+using netDxf.IO;
+
+namespace netDxf.Entities.MLeader.MLeaderGeometry;
+
+public class LeaderLine
+{
+    public List<Vector3> Verticies = new(); // WCS coordinates
+    public List<object> Breaks = new(); //TODO ???? how is it implemented?
+    // # Breaks: 90, 11, 12, [11, 12, ...] [, 90, 11, 12 [11, 12, ...]]
+    // # group code 90 = break index
+    // # group code 11 = start vertex of break
+    // # group code 12 = end vertex of break
+    // # multiple breaks per index possible
+    public int Index;  //group code 91
+    public int Color = -1056964608; //group code 92
+
+
+    public static LeaderLine Load(List<object> tags)
+    {
+        var firstTag = tags[0];
+
+        if (!(firstTag is ICodeValueReader tcv && tcv.Code == DxfReader.START_LEADER_LINE && (string)tcv.Value == DxfReader.LEADER_LINE_STR))
+        {
+            if (firstTag is ICodeValueReader t)
+            {
+                throw new Exception($"Cannot load LeaderLine - wrong start code: {t.Code} - {t.Value}");
+            }
+            else
+            {
+                throw new Exception($"Cannot load LeaderLine - wrong start code: {firstTag.GetType().Name}");
+            }
+        }
+        var line = new LeaderLine();
+
+        var XCoords = new List<double>(); //we can have unknown number of points :')
+        var YCoords = new List<double>();
+        var ZCoords = new List<double>();
+
+        foreach (var t in tags)
+        {
+
+            if (t is ICodeValueReader tagCodeValue)
+            {
+                switch (tagCodeValue.Code)
+                {
+                    case 10:
+                        XCoords.Add(tagCodeValue.ReadDouble());
+                        break;
+                    case 20:
+                        YCoords.Add(tagCodeValue.ReadDouble());
+                        break;
+                    case 30:
+                        ZCoords.Add(tagCodeValue.ReadDouble());
+                        break;
+                    case 91:
+                        line.Index = tagCodeValue.ReadInt();
+                        break;
+                    case 92:
+                        line.Color = tagCodeValue.ReadInt();
+                        break;
+                }
+            }
+            else
+            {
+                throw new Exception("Something wrong with types!");
+            }
+
+        }
+
+        if (XCoords.Count != YCoords.Count || YCoords.Count != ZCoords.Count)
+        {
+            throw new Exception($"Something wrong with LeaderLine points!: {XCoords.Count}, {YCoords.Count}, {ZCoords.Count}");
+        }
+
+        if (XCoords.Count > 0)
+        {
+            for (var i = 0; i < XCoords.Count; i++)
+            {
+                line.Verticies.Add(new Vector3(XCoords[i], YCoords[i], ZCoords[i]));
+            }
+        }
+
+
+
+        return line;
+    }
+
+    public LeaderLine Clone()
+    {
+
+        var clonedVerticies = new List<Vector3>() { };
+
+        foreach (var v in Verticies)
+        {
+            clonedVerticies.Add(new Vector3(v.X, v.Y, v.Z));
+        }
+        return new LeaderLine()
+        {
+            Verticies = clonedVerticies,
+            Breaks = Breaks,
+            Index = Index,
+            Color = Color,
+        };
+    }
+
+}

--- a/netDxf/Entities/MLeader/MLeaderGeometry/MLeaderContext.cs
+++ b/netDxf/Entities/MLeader/MLeaderGeometry/MLeaderContext.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+
+using netDxf.Entities.MLeader.InsertedData;
+using netDxf.IO;
+
+namespace netDxf.Entities.MLeader.MLeaderGeometry;
+
+public class MLeaderContext
+{
+    // ATTRIBS = {
+    //     40: "scale",
+    //     10: "base_point",
+    //     41: "char_height",
+    //     140: "arrow_head_size",
+    //     145: "landing_gap_size",
+    //     174: "left_attachment",
+    //     175: "right_attachment",
+    //     176: "text_align_type",
+    //     177: "attachment_type",
+    //     110: "plane_origin",
+    //     111: "plane_x_axis",
+    //     112: "plane_y_axis",
+    //     297: "plane_normal_reversed",
+    //     272: "top_attachment",
+    //     273: "bottom_attachment",
+    // }
+
+    // # MTEXT base point: is not the MTEXT insertion point!
+    // # HORIZONTAL leader attachment:
+    // # the "base_point" is always the start point of the leader on the LEFT side
+    // # of the MTEXT, regardless of alignment and which side leaders are attached.
+    // # VERTICAL leader attachment:
+    // # the "base_point" is always the start point of the leader on the BOTTOM
+    // # side of the MTEXT, regardless of alignment and which side leaders are
+    // # attached.
+    //
+    // # BLOCK base point: is not the BLOCK insertion point!
+    // # HORIZONTAL leader attachment:
+    // # Strange results, setting the "base_point" to the left center of the BLOCK,
+    // # regardless which side leaders are attached, seems to be reasonable.
+    // # VERTICAL leader attachment: not supported by BricsCAD
+
+    public List<LeaderData> Leaders = new();
+    public double Scale = 1.0;
+    public Vector3 BasePoint = Vector3.Zero;
+    public double CharHeight = 4.0;
+    public double ArrowHeadSize = 4.0;
+    public double LandingGapSize = 2.0;
+    public short LeftAttachment = 1;
+    public short RightAttachment = 1;
+    public short TextAlignType; //0=left, 1=center, 2=right
+    public short AttachmentType; //0=content extents, 1=insertion point
+    public MTextData? MText;
+    public BlockData? Block;
+    public Vector3 PlaneOrigin = Vector3.Zero;
+    public Vector3 PlaneXAxis = Vector3.UnitX;
+    public Vector3 PlaneYAxis = Vector3.UnitY;
+    public bool PlaneNormalReversed;
+    public int TopAttachment = 9;
+    public int BottomAttachment = 9;
+
+    public static MLeaderContext Load(List<object> contextTags)
+    {
+        var firstTag = contextTags[0];
+
+        if (!(firstTag is ICodeValueReader tcv && tcv.Code == DxfReader.START_CONTEXT_DATA && (string)tcv.Value == DxfReader.CONTEXT_STR))
+        {
+            if (firstTag is ICodeValueReader t)
+            {
+                throw new Exception($"Cannot load LeaderContext - wrong start code: {t.Code} - {t.Value}");
+            }
+            else
+            {
+                throw new Exception($"Cannot load LeaderContext - wrong start code: {firstTag.GetType().Name}");
+            }
+        }
+
+        var ctx = new MLeaderContext();
+        IMLeaderInsertedContent? content = null;
+
+
+        IMLeaderInsertedContent? insertedContent = null;
+
+        var insertedContentFound = false;
+
+        foreach (var tag in contextTags)
+        {
+
+            switch (tag)
+            {
+                case List<object> leaderDataTags:
+                    ctx.Leaders.Add(LeaderData.Load(leaderDataTags));
+                    break;
+                case ICodeValueReader tagCodeValue:
+
+                    if (insertedContentFound && insertedContent is not null) //We must add some properties to different, inserted object - it can be Text or Block
+                    {
+                        //Console.WriteLine($"This tag belongs to InsertedContent! {tagCodeValue.Code} - {tagCodeValue.Value}");
+                        if (insertedContent.ParseTag(tagCodeValue)) //changing Content Values inside - if tag is not connected with content - next values should be applied here
+                        {
+                            //Console.WriteLine($"Tag added to content");
+                            continue;
+                        }
+                        else
+                        {
+                            //Console.WriteLine($"Its time to stop!");
+                            insertedContentFound = false;
+                        }
+                    }
+
+                    switch (tagCodeValue.Code)
+                    {
+
+                        case 290 when tagCodeValue.ReadBool() == true:
+                            {
+                                ctx.MText = new MTextData();
+                                insertedContent = ctx.MText;
+                                insertedContentFound = true;
+                                break;
+                            }
+                        case 296 when tagCodeValue.ReadBool() == true:
+                            {
+                                ctx.Block = new BlockData();
+                                insertedContent = ctx.Block;
+                                insertedContentFound = true;
+                                break;
+                            }
+                        case 40:
+                            {
+                                ctx.Scale = tagCodeValue.ReadDouble();
+                                break;
+                            }
+
+                        case 41:
+                            {
+                                ctx.CharHeight = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 10:
+                            {
+                                ctx.BasePoint.X = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 20:
+                            {
+                                ctx.BasePoint.Y = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 30:
+                            {
+                                ctx.BasePoint.Z = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 140:
+                            {
+                                ctx.ArrowHeadSize = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 145:
+                            {
+                                ctx.LandingGapSize = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 174:
+                            {
+                                ctx.LeftAttachment = tagCodeValue.ReadShort();
+                                break;
+                            }
+                        case 175:
+                            {
+                                ctx.RightAttachment = tagCodeValue.ReadShort();
+                                break;
+                            }
+                        case 176:
+                            {
+                                ctx.TextAlignType = tagCodeValue.ReadShort();
+                                break;
+                            }
+                        case 177:
+                            {
+                                ctx.AttachmentType = tagCodeValue.ReadShort();
+                                break;
+                            }
+                        case 110:
+                            {
+                                ctx.PlaneOrigin.X = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 120:
+                            {
+                                ctx.PlaneOrigin.Y = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 130:
+                            {
+                                ctx.PlaneOrigin.Z = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 111:
+                            {
+                                ctx.PlaneXAxis.X = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 121:
+                            {
+                                ctx.PlaneXAxis.Y = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 131:
+                            {
+                                ctx.PlaneXAxis.Z = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 112:
+                            {
+                                ctx.PlaneYAxis.X = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 122:
+                            {
+                                ctx.PlaneYAxis.Y = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 132:
+                            {
+                                ctx.PlaneYAxis.Z = tagCodeValue.ReadDouble();
+                                break;
+                            }
+                        case 297:
+                            {
+                                ctx.PlaneNormalReversed = tagCodeValue.ReadBool();
+                                break;
+                            }
+                        case 272:
+                            {
+                                ctx.TopAttachment = tagCodeValue.ReadInt();
+                                break;
+                            }
+                        case 273:
+                            {
+                                ctx.BottomAttachment = tagCodeValue.ReadInt();
+                                break;
+                            }
+                    }
+
+                    break;
+                default:
+                    throw new Exception("Something wrong with types!");
+                    break;
+            }
+        }
+
+        return ctx;
+    }
+    public MLeaderContext Clone()
+    {
+        var clonedLeaders = new List<LeaderData>() { };
+
+        foreach (var leader in Leaders)
+        {
+            clonedLeaders.Add(leader.Clone());
+        }
+
+        MTextData? clonedMTextData = null;
+
+        if (MText is not null)
+        {
+            clonedMTextData = MText.Clone();
+        }
+
+        BlockData? clonedBlockData = null;
+
+        if (Block is not null)
+        {
+            clonedBlockData = Block.Clone();
+        }
+
+        return new MLeaderContext()
+        {
+            Leaders = clonedLeaders,
+            Scale = Scale,
+            BasePoint = new Vector3(BasePoint.X, BasePoint.Y, BasePoint.Z),
+            CharHeight = CharHeight,
+            ArrowHeadSize = ArrowHeadSize,
+            LandingGapSize = LandingGapSize,
+            LeftAttachment = LeftAttachment,
+            RightAttachment = RightAttachment,
+            TextAlignType = TextAlignType,
+            AttachmentType = AttachmentType,
+            MText = clonedMTextData,
+            Block = clonedBlockData,
+            PlaneOrigin = new Vector3(PlaneOrigin.X, PlaneOrigin.Y, PlaneOrigin.Z),
+            PlaneXAxis = new Vector3(PlaneXAxis.X, PlaneXAxis.Y, PlaneXAxis.Z),
+            PlaneNormalReversed = PlaneNormalReversed,
+            TopAttachment = TopAttachment,
+            BottomAttachment = BottomAttachment
+        };
+    }
+
+}

--- a/netDxf/Entities/MLeader/MLeaderGeometry/MLeaderType.cs
+++ b/netDxf/Entities/MLeader/MLeaderGeometry/MLeaderType.cs
@@ -1,0 +1,9 @@
+namespace netDxf.Entities.MLeader.MLeaderGeometry;
+
+public enum MLeaderType
+{
+
+    Invisible = 0,
+    StraightLine = 1,
+    Spline = 2
+}

--- a/netDxf/Entities/Ole2Frame.cs
+++ b/netDxf/Entities/Ole2Frame.cs
@@ -1,0 +1,174 @@
+#region netDxf library licensed under the MIT License
+//
+//                       netDxf library
+// Copyright (c) 2019-2021 Daniel Carvajal (haplokuon@gmail.com)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+#endregion
+
+using System;
+
+using netDxf.Tables;
+
+namespace netDxf.Entities;
+
+/// <summary>
+/// Represents a Ole2Frame entity.
+/// https://help.autodesk.com/view/OARX/2023/ENU/?guid=GUID-77747CE6-82C6-4452-97ED-4CEEB38BE960
+/// </summary>
+public class Ole2Frame :
+    EntityObject
+{
+    #region delegates and events
+
+    // public delegate void StyleChangedEventHandler(Ole2Frame sender, TableObjectChangedEventArgs<ShapeStyle> e);
+    // public event StyleChangedEventHandler StyleChanged;
+    // protected virtual ShapeStyle OnStyleChangedEvent(ShapeStyle oldStyle, ShapeStyle newStyle)
+    // {
+    //     StyleChangedEventHandler ae = this.StyleChanged;
+    //     if (ae != null)
+    //     {
+    //         TableObjectChangedEventArgs<ShapeStyle> eventArgs = new TableObjectChangedEventArgs<ShapeStyle>(oldStyle, newStyle);
+    //         ae(this, eventArgs);
+    //         return eventArgs.NewValue;
+    //     }
+    //     return newStyle;
+    // }
+
+    #endregion
+
+    #region private fields
+
+    private short oleVersionNumber;
+    private Vector3 upperLeftCorner;
+    private Vector3 lowerRightCorner;
+    private Byte[] oleFrameBytes;
+    private Ole2FrameType ole2FrameType;
+
+    #endregion
+
+    #region constructors
+
+
+    /// <summary>
+    /// Initializes a new instance of the <c>Ole2Frame</c> class.
+    /// </summary>
+
+    public Ole2Frame(short oleVersionNumber, Vector3 upperLeftCorner, Vector3 lowerRightCorner, Byte[] oleFrameBytes, Ole2FrameType ole2FrameType)
+        : base(EntityType.Ole2Frame, DxfObjectCode.Ole2FrameSection)
+    {
+        this.oleVersionNumber = oleVersionNumber;
+        this.upperLeftCorner = upperLeftCorner;
+        this.lowerRightCorner = lowerRightCorner;
+        this.oleFrameBytes = oleFrameBytes;
+        this.ole2FrameType = ole2FrameType;
+    }
+
+    #endregion
+
+    #region public properties
+
+
+    public Vector3 UpperLeftCorner
+    {
+        get { return this.upperLeftCorner; }
+        set { this.upperLeftCorner = value; }
+    }
+
+    public Vector3 LowerRightCorner
+    {
+        get
+        {
+            return this.lowerRightCorner;
+        }
+        set { this.lowerRightCorner = value; }
+    }
+
+    public short OleVersionNumber
+    {
+        get { return this.oleVersionNumber; }
+        set { this.oleVersionNumber = value; }
+    }
+
+    public Byte[] OleFrameBytes
+    {
+        get { return this.oleFrameBytes; }
+        set { this.oleFrameBytes = value; }
+    }
+
+    public Ole2FrameType Ole2FrameType
+    {
+        get { return this.ole2FrameType; }
+        set { this.ole2FrameType = value; }
+    }
+
+    #endregion
+
+    #region overrides
+
+    /// <summary>
+    /// Moves, scales, and/or rotates the current entity given a 3x3 transformation matrix and a translation vector.
+    /// </summary>
+    /// <param name="transformation">Transformation matrix.</param>
+    /// <param name="translation">Translation vector.</param>
+    /// <remarks>Matrix3 adopts the convention of using column vectors to represent a transformation matrix.</remarks>
+    public override void TransformBy(Matrix3 transformation, Vector3 translation)
+    {
+
+        var newUpperLeftPosition = transformation * this.UpperLeftCorner + translation;
+        var newLowerRightPosition = transformation * this.LowerRightCorner + translation;
+        var newNormal = transformation * this.Normal;
+
+        this.UpperLeftCorner = newUpperLeftPosition;
+        this.LowerRightCorner = newLowerRightPosition;
+        this.Normal = newNormal;
+    }
+
+    public override object Clone()
+    {
+        var entity = new Ole2Frame(this.OleVersionNumber, this.UpperLeftCorner, this.LowerRightCorner, this.OleFrameBytes, this.Ole2FrameType)
+        {
+            //EntityObject properties
+            Layer = (Layer)this.Layer.Clone(),
+            Linetype = (Linetype)this.Linetype.Clone(),
+            Color = (AciColor)this.Color.Clone(),
+            Lineweight = this.Lineweight,
+            Transparency = (Transparency)this.Transparency.Clone(),
+            LinetypeScale = this.LinetypeScale,
+            Normal = this.Normal,
+            IsVisible = this.IsVisible,
+            //Ole2FrameProperties
+            UpperLeftCorner = this.UpperLeftCorner,
+            LowerRightCorner = this.LowerRightCorner,
+            OleVersionNumber = this.OleVersionNumber,
+            OleFrameBytes = this.OleFrameBytes,
+            Ole2FrameType = this.Ole2FrameType
+        };
+
+        foreach (var data in this.XData.Values)
+        {
+            entity.XData.Add((XData)data.Clone());
+        }
+
+        return entity;
+    }
+
+    #endregion
+}

--- a/netDxf/Entities/Ole2FrameType.cs
+++ b/netDxf/Entities/Ole2FrameType.cs
@@ -1,0 +1,8 @@
+namespace netDxf.Entities;
+
+public enum Ole2FrameType
+{
+    Link,
+    Embedded,
+    Static
+}

--- a/netDxf/IO/BinaryCodeValueReader.cs
+++ b/netDxf/IO/BinaryCodeValueReader.cs
@@ -46,6 +46,14 @@ namespace netDxf.IO
 
         #region constructors
 
+        private BinaryCodeValueReader(BinaryReader reader, short code, object value, Encoding encoding)
+        {
+            this.reader = reader;
+            this.code = code;
+            this.value = value;
+            this.encoding = encoding;
+        }
+        
         public BinaryCodeValueReader(BinaryReader reader, Encoding encoding)
         {
             this.reader = reader;
@@ -352,6 +360,8 @@ namespace netDxf.IO
 
         }
 
-        #endregion       
+        #endregion  
+        
+        public ICodeValueReader Clone() => new BinaryCodeValueReader(reader, Code, Value, encoding);
     }
 }

--- a/netDxf/IO/DxfReader.cs
+++ b/netDxf/IO/DxfReader.cs
@@ -8556,7 +8556,7 @@ namespace netDxf.IO
             return insert;
         }
 
-  private MLeader ReadMLeader()
+    private MLeader ReadMLeader()
     {
 
         // How to render MLEADER: https://atlight.github.io/formats/dxf-leader.html
@@ -8598,6 +8598,36 @@ namespace netDxf.IO
             }
 
         }
+
+
+        //DxfMLeaderRebuilder.DebugMLeaderMContext(rebuildedMLeaderContext, allMleaderChunks);
+
+        var mleader = MLeader.Load(normalOtherTags, rebuildedMLeaderContext);
+
+        if (mleader.Context.MText is not null) // we must update MText style here
+        {
+
+            foreach (var style in this.doc.TextStyles)
+            {
+                if (style.Handle == mleader.Context.MText.StyleHandle)
+                {
+                    mleader.Context.MText.TextStyle = style;
+                    break;
+                }
+            }
+        }
+
+
+
+        mleader.XData.AddRange(xData);
+        if (mleader.StyleHandle is not null)
+        {
+            this.mLeaderToStyleHandle.Add(mleader, mleader.StyleHandle);
+        }
+
+        return mleader;
+
+    }
 
     private List<object> CompileMLeaderContextTags() // returns Tree structure
     {

--- a/netDxf/IO/ICodeValueReader.cs
+++ b/netDxf/IO/ICodeValueReader.cs
@@ -52,5 +52,7 @@ namespace netDxf.IO
         double ReadDouble();
         string ReadString();
         string ReadHex();
+        
+        public ICodeValueReader Clone();
     }
 }

--- a/netDxf/IO/TextCodeValueReader.cs
+++ b/netDxf/IO/TextCodeValueReader.cs
@@ -53,6 +53,14 @@ namespace netDxf.IO
             this.currentPosition = 0;
         }
 
+        private TextCodeValueReader(TextReader reader, short code, object value, long currentPosition)
+        {
+            this.reader = reader;
+            this.code = code;
+            this.value = value;
+            this.currentPosition = currentPosition;
+        }
+        
         #endregion
 
         #region public properties
@@ -435,5 +443,6 @@ namespace netDxf.IO
         }
 
         #endregion
+        public ICodeValueReader Clone() => new TextCodeValueReader(reader, Code, Value, CurrentPosition);
     }
 }


### PR DESCRIPTION
Hi! 
I'm using this code and I was missing the ability to load OleFrame and MLeader objects from dxf file.
So I tried to implement it. It's far from perfect, but it allows you to "somehow" load data.
In order to implement it I used:

- [ezdxf open-source python library](https://ezdxf.readthedocs.io/en/stable/ )
- [How to render MLeader]( https://atlight.github.io/formats/dxf-leader.html)
- AutoCad docs

MLeader structure is very hard to understand and its very ugly. I was inspired mainly by the ezdxf code and [this](https://atlight.github.io/formats/dxf-leader.html) page.

Unfortunately, I do not fully understand the entire code and have not found the time to create WriteFunctions / Tests. 
I hope this code will be useful to someone, or you will be able to improve it :)